### PR TITLE
feat: ExpenseContext - Phase 2 frontend state management

### DIFF
--- a/.kiro/specs/expense-context/tasks.md
+++ b/.kiro/specs/expense-context/tasks.md
@@ -7,7 +7,7 @@ This implementation plan extracts expense data state, fetching logic, CRUD handl
 ## Tasks
 
 - [ ] 1. Create ExpenseContext module
-  - [ ] 1.1 Create `frontend/src/contexts/ExpenseContext.jsx` with ExpenseProvider and useExpenseContext
+  - [x] 1.1 Create `frontend/src/contexts/ExpenseContext.jsx` with ExpenseProvider and useExpenseContext
     - Implement core state (expenses, loading, error, refreshTrigger, budgetAlertRefreshTrigger, currentMonthExpenseCount)
     - Consume FilterContext internally via useFilterContext for view mode and filter values
     - Implement expense fetch effect with view-mode-aware URL construction
@@ -19,7 +19,7 @@ This implementation plan extracts expense data state, fetching logic, CRUD handl
     - Export useExpenseContext hook with descriptive error when used outside provider
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 6.1, 6.2, 7.1, 7.2, 7.3, 8.1, 8.2, 8.3_
 
-  - [ ] 1.2 Write unit tests for ExpenseContext
+  - [x] 1.2 Write unit tests for ExpenseContext
     - Test useExpenseContext throws outside provider
     - Test ExpenseProvider requires FilterProvider (throws FilterContext error)
     - Test initial state values (empty array, loading false, error null)
@@ -29,52 +29,52 @@ This implementation plan extracts expense data state, fetching logic, CRUD handl
     - Test expensesUpdated event triggers refresh
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.2, 3.7, 3.8, 6.1, 6.2, 8.2_
 
-- [ ] 2. Checkpoint - Ensure context module tests pass
+- [x] 2. Checkpoint - Ensure context module tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
 - [ ] 3. Write property tests for fetch and loading behavior
-  - [ ]* 3.1 Write property test for fetch URL construction
+  - [x] 3.1 Write property test for fetch URL construction
     - **Property 1: Fetch URL construction matches view mode**
     - Generate random year/month/filterYear/isGlobalView combinations
     - Verify URL matches expected pattern for each view mode
     - **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
 
-  - [ ]* 3.2 Write property test for loading state transitions
+  - [x] 3.2 Write property test for loading state transitions
     - **Property 2: Loading state transitions during fetch**
     - Verify loading is true during fetch, false after completion
     - **Validates: Requirements 3.5, 3.6, 3.7, 3.8**
 
 - [ ] 4. Write property tests for CRUD handlers
-  - [ ]* 4.1 Write property test for handleExpenseAdded sorted insertion
+  - [x] 4.1 Write property test for handleExpenseAdded sorted insertion
     - **Property 3: handleExpenseAdded inserts in date-sorted order**
     - Generate random expense arrays and new expenses within current view
     - Verify resulting array contains new expense and is date-sorted
     - **Validates: Requirements 4.1**
 
-  - [ ]* 4.2 Write property test for handleExpenseAdded view filtering
+  - [x] 4.2 Write property test for handleExpenseAdded view filtering
     - **Property 4: handleExpenseAdded skips out-of-view expenses**
     - Generate expenses with year/month not matching selected view in monthly mode
     - Verify array length unchanged
     - **Validates: Requirements 4.2**
 
-  - [ ]* 4.3 Write property test for handleExpenseDeleted
+  - [x] 4.3 Write property test for handleExpenseDeleted
     - **Property 5: handleExpenseDeleted removes exactly the target expense**
     - Generate arrays with unique IDs, delete random ID
     - Verify length reduced by 1 and deleted ID absent
     - **Validates: Requirements 4.4**
 
-  - [ ]* 4.4 Write property test for handleExpenseUpdated
+  - [x] 4.4 Write property test for handleExpenseUpdated
     - **Property 6: handleExpenseUpdated replaces the matching expense**
     - Generate arrays, update random expense, verify replacement
     - **Validates: Requirements 4.6**
 
-  - [ ]* 4.5 Write property test for CRUD refreshTrigger increment
+  - [x] 4.5 Write property test for CRUD refreshTrigger increment
     - **Property 7: CRUD operations increment refreshTrigger**
     - Verify refreshTrigger increases by 1 for each add/delete/update
     - **Validates: Requirements 4.3, 4.5, 4.7**
 
 - [ ] 5. Write property test for client-side filtering
-  - [ ]* 5.1 Write property test for filtering with AND logic
+  - [x] 5.1 Write property test for filtering with AND logic
     - **Property 8: Client-side filtering with AND logic**
     - Generate random expenses and filter combinations (searchText, filterType, filterMethod)
     - Verify filteredExpenses matches manual AND-logic filtering
@@ -82,15 +82,15 @@ This implementation plan extracts expense data state, fetching logic, CRUD handl
     - Verify no filters returns full array
     - **Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6**
 
-- [ ] 6. Checkpoint - Ensure all context and property tests pass
+- [x] 6. Checkpoint - Ensure all context and property tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 7. Integrate ExpenseContext into App.jsx
-  - [ ] 7.1 Wrap AppContent with ExpenseProvider inside FilterProvider
+- [x] 7. Integrate ExpenseContext into App.jsx
+  - [x] 7.1 Wrap AppContent with ExpenseProvider inside FilterProvider
     - Add ExpenseProvider between FilterProvider and AppContent in App component
     - _Requirements: 9.1_
 
-  - [ ] 7.2 Consume ExpenseContext in AppContent and remove extracted state
+  - [x] 7.2 Consume ExpenseContext in AppContent and remove extracted state
     - Add useExpenseContext() call in AppContent
     - Remove useState hooks: expenses, loading, error, refreshTrigger, currentMonthExpenseCount, budgetAlertRefreshTrigger
     - Remove expense fetch useEffect
@@ -101,27 +101,27 @@ This implementation plan extracts expense data state, fetching logic, CRUD handl
     - Replace all references with context values
     - _Requirements: 9.2, 9.3, 9.4, 9.5_
 
-  - [ ] 7.3 Wire up remaining AppContent interactions with context
+  - [x] 7.3 Wire up remaining AppContent interactions with context
     - Wrap context handleExpenseAdded to also close expense form modal (setShowExpenseForm(false))
     - Update retry button to use clearError + triggerRefresh from context
     - Continue passing expense values to child components as props for backward compatibility
     - _Requirements: 9.6, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8_
 
-  - [ ]* 7.4 Write integration tests for App.jsx with ExpenseContext
+  - [x] 7.4 Write integration tests for App.jsx with ExpenseContext
     - Test expense data flows to ExpenseList via props
     - Test CRUD handlers update context state correctly
     - Test view mode changes trigger re-fetch
     - Test filtered expenses update when filters change
     - _Requirements: 10.1, 10.5, 10.7_
 
-- [ ] 8. Final checkpoint - Ensure all tests pass
+- [x] 8. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
   - Verify App.jsx line count is reduced
   - Verify no user-facing behavior changes
 
 ## Notes
 
-- Tasks marked with `*` are optional and can be skipped for faster MVP
+- All tasks are mandatory
 - Each task references specific requirements for traceability
 - Checkpoints ensure incremental validation
 - Property tests validate universal correctness properties

--- a/frontend/src/App.expenseContext.integration.test.jsx
+++ b/frontend/src/App.expenseContext.integration.test.jsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from './App';
+
+/**
+ * Integration tests for App.jsx with ExpenseContext
+ * Validates that expense data flows correctly from ExpenseProvider to child components,
+ * CRUD handlers update context state, view mode changes trigger re-fetch,
+ * and filtered expenses update when filters change.
+ *
+ * **Validates: Requirements 10.1, 10.5, 10.7**
+ */
+
+describe('App.jsx ExpenseContext Integration', () => {
+  let mockFetch;
+
+  const mockExpenses = [
+    { id: 1, date: '2026-02-10', place: 'Walmart', notes: 'Groceries', amount: 50, type: 'Groceries', method: 'Debit', week: 2 },
+    { id: 2, date: '2026-02-15', place: 'Shell', notes: 'Gas fill', amount: 40, type: 'Gas', method: 'Cash', week: 3 },
+    { id: 3, date: '2026-02-20', place: 'Amazon', notes: 'Books', amount: 30, type: 'Entertainment', method: 'Debit', week: 3 },
+  ];
+
+  const defaultMockImpl = (url, options) => {
+    if (url.includes('/api/version')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ version: '5.6.1' }) });
+    }
+    if (url.includes('/api/payment-methods')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          paymentMethods: [
+            { id: 1, display_name: 'Debit', type: 'debit', is_active: 1 },
+            { id: 2, display_name: 'Cash', type: 'cash', is_active: 1 },
+          ]
+        })
+      });
+    }
+    if (url.includes('/api/people')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (url.includes('/api/summary')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          totalExpenses: 120, weeklyTotals: {}, monthlyGross: 3000,
+          remaining: 2880, typeTotals: {}, methodTotals: {}
+        })
+      });
+    }
+    if (url.includes('/api/budgets/summary')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ totalBudget: 0, totalSpent: 0 }) });
+    }
+    if (url.includes('/api/budgets')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (url.includes('/api/fixed-expenses')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (url.includes('/api/income')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (url.includes('/api/loans')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    if (url.includes('/api/expenses')) {
+      if (url.includes('year=') && url.includes('month=')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockExpenses) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockExpenses) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+  };
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockImplementation(defaultMockImpl);
+    global.fetch = mockFetch;
+  });
+
+  /**
+   * Test: Expense data flows from ExpenseContext to ExpenseList via props
+   * Validates: Requirement 10.1
+   */
+  it('should display expenses from ExpenseContext in ExpenseList', async () => {
+    render(<App />);
+
+    // Wait for expenses to load and render in the table
+    await waitFor(() => {
+      const table = screen.getByRole('table');
+      const rows = within(table).getAllByRole('row');
+      const dataRows = rows.filter(row => row.querySelector('td'));
+      expect(dataRows.length).toBe(3);
+    });
+
+    // Verify specific expense data is displayed
+    expect(screen.getByText('Walmart')).toBeInTheDocument();
+    expect(screen.getByText('Shell')).toBeInTheDocument();
+    expect(screen.getByText('Amazon')).toBeInTheDocument();
+  });
+
+  /**
+   * Test: View mode changes trigger re-fetch with correct URL
+   * Validates: Requirement 10.7
+   */
+  it('should re-fetch expenses when view mode changes from monthly to global', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for initial monthly load
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /expense tracker/i })).toBeInTheDocument();
+    });
+
+    // Verify initial monthly fetch was made
+    await waitFor(() => {
+      const monthlyCall = mockFetch.mock.calls.find(call =>
+        call[0].includes('/api/expenses?year=') && call[0].includes('month=')
+      );
+      expect(monthlyCall).toBeDefined();
+    });
+
+    // Apply payment method filter to trigger global view
+    const paymentFilter = screen.getByLabelText(/filter by payment method/i);
+    await user.selectOptions(paymentFilter, 'Debit');
+
+    // Should trigger a global fetch (no year/month params)
+    await waitFor(() => {
+      const globalCall = mockFetch.mock.calls.find(call =>
+        call[0].includes('/api/expenses') &&
+        !call[0].includes('year=') &&
+        !call[0].includes('month=')
+      );
+      expect(globalCall).toBeDefined();
+    });
+  });
+
+  /**
+   * Test: Filtered expenses update when filters change
+   * Validates: Requirement 10.5
+   */
+  it('should filter displayed expenses when category filter is applied', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Wait for all expenses to load
+    await waitFor(() => {
+      const table = screen.getByRole('table');
+      const rows = within(table).getAllByRole('row');
+      const dataRows = rows.filter(row => row.querySelector('td'));
+      expect(dataRows.length).toBe(3);
+    });
+
+    // Apply category filter for Groceries
+    const categoryFilter = screen.getByLabelText(/filter by expense category/i);
+    await user.selectOptions(categoryFilter, 'Groceries');
+
+    // Should show only Groceries expenses (client-side filtering from context)
+    await waitFor(() => {
+      const table = screen.getByRole('table');
+      const rows = within(table).getAllByRole('row');
+      const dataRows = rows.filter(row => row.querySelector('td'));
+      expect(dataRows.length).toBe(1);
+    });
+
+    // Verify the correct expense is shown
+    expect(screen.getByText('Walmart')).toBeInTheDocument();
+    expect(screen.queryByText('Shell')).not.toBeInTheDocument();
+    expect(screen.queryByText('Amazon')).not.toBeInTheDocument();
+  });
+
+  /**
+   * Test: CRUD handler (delete) updates context state correctly
+   * Validates: Requirement 10.1
+   */
+  it('should remove expense from list when delete handler is called via context', async () => {
+    const user = userEvent.setup();
+
+    // Add DELETE support to mock
+    mockFetch.mockImplementation((url, options) => {
+      if (options?.method === 'DELETE' && url.includes('/api/expenses/')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ message: 'Deleted' }) });
+      }
+      return defaultMockImpl(url, options);
+    });
+
+    render(<App />);
+
+    // Wait for expenses to load
+    await waitFor(() => {
+      const table = screen.getByRole('table');
+      const rows = within(table).getAllByRole('row');
+      const dataRows = rows.filter(row => row.querySelector('td'));
+      expect(dataRows.length).toBe(3);
+    });
+
+    // Find and click the delete button for the first expense
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+    const firstDataRow = rows.find(row => row.querySelector('td'));
+    const deleteButton = within(firstDataRow).getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    // ExpenseList shows a confirm dialog — click the confirm button
+    const confirmButton = await screen.findByRole('button', { name: /^delete$/i });
+    await user.click(confirmButton);
+
+    // After deletion, the expense should be removed from the list
+    await waitFor(() => {
+      const updatedTable = screen.getByRole('table');
+      const updatedRows = within(updatedTable).getAllByRole('row');
+      const updatedDataRows = updatedRows.filter(row => row.querySelector('td'));
+      expect(updatedDataRows.length).toBe(2);
+    });
+  });
+});

--- a/frontend/src/contexts/ExpenseContext.jsx
+++ b/frontend/src/contexts/ExpenseContext.jsx
@@ -1,0 +1,210 @@
+import { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
+import { API_ENDPOINTS } from '../config';
+import { useFilterContext } from './FilterContext';
+
+const ExpenseContext = createContext(null);
+
+/**
+ * ExpenseProvider - Manages expense data, fetching, CRUD, and filtering
+ * 
+ * Must be nested inside FilterProvider (consumes FilterContext internally).
+ */
+export function ExpenseProvider({ children }) {
+  const {
+    searchText, filterType, filterMethod, filterYear,
+    selectedYear, selectedMonth, isGlobalView,
+  } = useFilterContext();
+
+  // Core expense state
+  const [expenses, setExpenses] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [currentMonthExpenseCount, setCurrentMonthExpenseCount] = useState(0);
+
+  // Budget alert refresh trigger (exposed for AppContent to use)
+  const [budgetAlertRefreshTrigger, setBudgetAlertRefreshTrigger] = useState(0);
+
+  // --- Expense Fetching ---
+  useEffect(() => {
+    const fetchExpenses = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let url;
+        if (isGlobalView) {
+          url = filterYear
+            ? `${API_ENDPOINTS.EXPENSES}?year=${filterYear}`
+            : API_ENDPOINTS.EXPENSES;
+        } else {
+          url = `${API_ENDPOINTS.EXPENSES}?year=${selectedYear}&month=${selectedMonth}`;
+        }
+        const response = await fetch(url);
+        if (!response.ok) {
+          const errorText = await response.text();
+          let errorMessage = 'Unable to load expenses. Please try again.';
+          try {
+            const errorData = JSON.parse(errorText);
+            errorMessage = errorData.error || errorMessage;
+          } catch { /* use default */ }
+          throw new Error(errorMessage);
+        }
+        const data = await response.json();
+        setExpenses(data);
+      } catch (err) {
+        let userMessage = err.message;
+        if (err.message.includes('fetch') || err.message.includes('NetworkError') || err.message.includes('Failed to fetch')) {
+          userMessage = 'Unable to connect to the server. Please check your connection and try again.';
+        }
+        setError(userMessage);
+        console.error('Error fetching expenses:', err);
+        // Keep existing expenses if we have them
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchExpenses();
+  }, [selectedYear, selectedMonth, isGlobalView, filterYear]);
+
+  // --- expensesUpdated Event Listener ---
+  useEffect(() => {
+    const handleExpensesUpdated = () => {
+      setRefreshTrigger(prev => prev + 1);
+      setBudgetAlertRefreshTrigger(prev => prev + 1);
+      // Re-fetch expenses
+      const refetch = async () => {
+        try {
+          let url;
+          if (isGlobalView) {
+            url = filterYear
+              ? `${API_ENDPOINTS.EXPENSES}?year=${filterYear}`
+              : API_ENDPOINTS.EXPENSES;
+          } else {
+            url = `${API_ENDPOINTS.EXPENSES}?year=${selectedYear}&month=${selectedMonth}`;
+          }
+          const response = await fetch(url);
+          if (response.ok) {
+            const data = await response.json();
+            setExpenses(data);
+          }
+        } catch (err) {
+          console.error('Error refreshing expenses:', err);
+        }
+      };
+      refetch();
+    };
+    window.addEventListener('expensesUpdated', handleExpensesUpdated);
+    return () => window.removeEventListener('expensesUpdated', handleExpensesUpdated);
+  }, [selectedYear, selectedMonth, isGlobalView, filterYear]);
+
+  // --- Current Month Expense Count ---
+  useEffect(() => {
+    let isMounted = true;
+    const fetchCount = async () => {
+      try {
+        const now = new Date();
+        const url = `${API_ENDPOINTS.EXPENSES}?year=${now.getFullYear()}&month=${now.getMonth() + 1}`;
+        const response = await fetch(url);
+        if (response.ok && isMounted) {
+          const data = await response.json();
+          setCurrentMonthExpenseCount(data.length);
+        }
+      } catch (err) {
+        if (isMounted) console.error('Error fetching current month expense count:', err);
+      }
+    };
+    fetchCount();
+    return () => { isMounted = false; };
+  }, [refreshTrigger]);
+
+  // --- CRUD Handlers ---
+  const handleExpenseAdded = useCallback((newExpense) => {
+    const dateParts = newExpense.date.split('-');
+    const expenseYear = parseInt(dateParts[0], 10);
+    const expenseMonth = parseInt(dateParts[1], 10);
+    if (isGlobalView || (expenseYear === selectedYear && expenseMonth === selectedMonth)) {
+      setExpenses(prev => {
+        const newList = [...prev, newExpense];
+        newList.sort((a, b) => new Date(a.date) - new Date(b.date));
+        return newList;
+      });
+    }
+    setRefreshTrigger(prev => prev + 1);
+    setBudgetAlertRefreshTrigger(prev => prev + 1);
+  }, [isGlobalView, selectedYear, selectedMonth]);
+
+  const handleExpenseDeleted = useCallback((deletedId) => {
+    setExpenses(prev => prev.filter(e => e.id !== deletedId));
+    setRefreshTrigger(prev => prev + 1);
+    setBudgetAlertRefreshTrigger(prev => prev + 1);
+  }, []);
+
+  const handleExpenseUpdated = useCallback((updatedExpense) => {
+    setExpenses(prev => prev.map(e => e.id === updatedExpense.id ? updatedExpense : e));
+    setRefreshTrigger(prev => prev + 1);
+    setBudgetAlertRefreshTrigger(prev => prev + 1);
+  }, []);
+
+  const triggerRefresh = useCallback(() => {
+    setRefreshTrigger(prev => prev + 1);
+  }, []);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  // --- Client-Side Filtering ---
+  const filteredExpenses = useMemo(() => {
+    return expenses.filter(expense => {
+      if (searchText) {
+        const searchLower = searchText.toLowerCase();
+        const placeMatch = expense.place && expense.place.toLowerCase().includes(searchLower);
+        const notesMatch = expense.notes && expense.notes.toLowerCase().includes(searchLower);
+        if (!placeMatch && !notesMatch) return false;
+      }
+      if (filterType && expense.type !== filterType) return false;
+      if (filterMethod && expense.method !== filterMethod) return false;
+      return true;
+    });
+  }, [expenses, searchText, filterType, filterMethod]);
+
+  // --- Context Value ---
+  const value = useMemo(() => ({
+    expenses,
+    filteredExpenses,
+    loading,
+    error,
+    refreshTrigger,
+    budgetAlertRefreshTrigger,
+    currentMonthExpenseCount,
+    handleExpenseAdded,
+    handleExpenseDeleted,
+    handleExpenseUpdated,
+    triggerRefresh,
+    clearError,
+  }), [
+    expenses, filteredExpenses, loading, error,
+    refreshTrigger, budgetAlertRefreshTrigger, currentMonthExpenseCount,
+    handleExpenseAdded, handleExpenseDeleted, handleExpenseUpdated,
+    triggerRefresh, clearError,
+  ]);
+
+  return (
+    <ExpenseContext.Provider value={value}>
+      {children}
+    </ExpenseContext.Provider>
+  );
+}
+
+/**
+ * useExpenseContext - Custom hook for consuming expense context
+ */
+export function useExpenseContext() {
+  const context = useContext(ExpenseContext);
+  if (context === null) {
+    throw new Error('useExpenseContext must be used within an ExpenseProvider');
+  }
+  return context;
+}
+
+export default ExpenseContext;

--- a/frontend/src/contexts/ExpenseContext.pbt.test.jsx
+++ b/frontend/src/contexts/ExpenseContext.pbt.test.jsx
@@ -1,0 +1,2603 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
+import * as fc from 'fast-check';
+import { FilterProvider, useFilterContext } from './FilterContext';
+import { ExpenseProvider, useExpenseContext } from './ExpenseContext';
+
+// Hook that returns both filter and expense context values
+function useBothContexts() {
+  const filter = useFilterContext();
+  const expense = useExpenseContext();
+  return { filter, expense };
+}
+
+describe('ExpenseContext Property-Based Tests', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  // Helper: create a mock fetch that records URLs
+  function createMockFetch() {
+    const calls = [];
+    const mockFn = vi.fn().mockImplementation(async (url) => {
+      calls.push(url);
+      return {
+        ok: true,
+        json: async () => [],
+        text: async () => '[]',
+      };
+    });
+    return { mockFn, calls };
+  }
+
+  /**
+   * **Feature: expense-context, Property 1: Fetch URL construction matches view mode**
+   *
+   * For any combination of view mode (monthly vs global), selectedYear, selectedMonth,
+   * and filterYear, the expense fetch URL SHALL be:
+   * - `?year={selectedYear}&month={selectedMonth}` when in monthly view
+   * - no query params when in global view with no year filter
+   * - `?year={filterYear}` when in global view with a year filter
+   *
+   * **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+   */
+  describe('Property 1: Fetch URL construction matches view mode', () => {
+    /**
+     * Property 1a: Monthly view fetch URL includes year and month
+     * (Req 3.1) - In monthly view, URL = EXPENSES?year={selectedYear}&month={selectedMonth}
+     */
+    it('1a: monthly view constructs URL with year and month params', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          async (year, month) => {
+            cleanup();
+            const { mockFn, calls } = createMockFetch();
+            globalThis.fetch = mockFn;
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Clear recorded calls, then change month
+            calls.length = 0;
+
+            act(() => {
+              result.current.filter.handleMonthChange(year, month);
+            });
+
+            // Wait for the re-fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in monthly view
+            expect(result.current.filter.isGlobalView).toBe(false);
+
+            // Find the expense fetch call with the correct year and month
+            const expenseFetchUrl = calls.find(
+              (url) => url.includes('/api/expenses') &&
+                       url.includes(`year=${year}`) &&
+                       url.includes(`month=${month}`)
+            );
+
+            expect(expenseFetchUrl).toBeDefined();
+            // Verify it has both year AND month params
+            expect(expenseFetchUrl).toMatch(/\?year=\d+&month=\d+/);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 1b: Global view without year filter constructs URL with no query params
+     * (Req 3.2) - In global view with no year filter, URL = EXPENSES (no params)
+     */
+    it('1b: global view without year filter constructs URL with no query params', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          // Use a non-empty search text to trigger global view without setting filterYear
+          fc.string({ minLength: 1, maxLength: 20 }).filter(s => s.trim().length > 0),
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          async (searchText, year, month) => {
+            cleanup();
+            const { mockFn, calls } = createMockFetch();
+            globalThis.fetch = mockFn;
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set month first
+            act(() => {
+              result.current.filter.handleMonthChange(year, month);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Clear recorded calls, then trigger global view via search text
+            calls.length = 0;
+
+            act(() => {
+              result.current.filter.handleSearchChange(searchText);
+            });
+
+            // Wait for re-fetch
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in global view
+            expect(result.current.filter.isGlobalView).toBe(true);
+
+            // The expense fetch URL should have NO query params (ends with /api/expenses)
+            const globalFetchUrl = calls.find(
+              (url) => url.endsWith('/api/expenses')
+            );
+
+            expect(globalFetchUrl).toBeDefined();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 1c: Global view with year filter constructs URL with only year param
+     * (Req 3.3) - In global view with year filter, URL = EXPENSES?year={filterYear}
+     */
+    it('1c: global view with year filter constructs URL with year-only param', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          async (filterYear, selectedYear, selectedMonth) => {
+            cleanup();
+            const { mockFn, calls } = createMockFetch();
+            globalThis.fetch = mockFn;
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set month
+            act(() => {
+              result.current.filter.handleMonthChange(selectedYear, selectedMonth);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Clear recorded calls, then set filterYear (triggers global view)
+            calls.length = 0;
+
+            act(() => {
+              result.current.filter.handleFilterYearChange(String(filterYear));
+            });
+
+            // Wait for re-fetch
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in global view
+            expect(result.current.filter.isGlobalView).toBe(true);
+
+            // The expense fetch URL should have year=filterYear but NO month param
+            const yearFilterUrl = calls.find(
+              (url) => url.includes('/api/expenses') &&
+                       url.includes(`year=${filterYear}`) &&
+                       !url.includes('month=')
+            );
+
+            expect(yearFilterUrl).toBeDefined();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 1d: View mode change triggers re-fetch with correct URL
+     * (Req 3.4) - When isGlobalView or filterYear changes, re-fetch occurs
+     * Tests the transition from monthly → global → monthly
+     */
+    it('1d: view mode transitions trigger re-fetch with correct URL pattern', { timeout: 120000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.string({ minLength: 1, maxLength: 20 }).filter(s => s.trim().length > 0),
+          async (year, month, searchText) => {
+            cleanup();
+            const { mockFn, calls } = createMockFetch();
+            globalThis.fetch = mockFn;
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial monthly fetch
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set specific month
+            act(() => {
+              result.current.filter.handleMonthChange(year, month);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in monthly view
+            expect(result.current.filter.isGlobalView).toBe(false);
+
+            // Clear and switch to global view
+            calls.length = 0;
+
+            act(() => {
+              result.current.filter.handleSearchChange(searchText);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Should have fetched with global URL (no params)
+            expect(result.current.filter.isGlobalView).toBe(true);
+            const globalUrl = calls.find(url => url.endsWith('/api/expenses'));
+            expect(globalUrl).toBeDefined();
+
+            // Clear and return to monthly view
+            calls.length = 0;
+
+            act(() => {
+              result.current.filter.handleReturnToMonthlyView();
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Should have fetched with monthly URL (year + month params)
+            expect(result.current.filter.isGlobalView).toBe(false);
+            const monthlyUrl = calls.find(
+              (url) => url.includes(`year=${year}`) && url.includes(`month=${month}`)
+            );
+            expect(monthlyUrl).toBeDefined();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 2: Loading state transitions during fetch**
+   *
+   * For any expense fetch cycle (triggered by view mode or filter changes),
+   * loading SHALL be true while the fetch is in progress and false after it
+   * completes (whether success or failure).
+   *
+   * **Validates: Requirements 3.5, 3.6, 3.7, 3.8**
+   */
+  describe('Property 2: Loading state transitions during fetch', () => {
+    // Helper: create a deferred fetch mock that we can resolve/reject manually
+    function createDeferredFetch() {
+      let resolvePromise;
+      let rejectPromise;
+      const calls = [];
+      const mockFn = vi.fn().mockImplementation((url) => {
+        calls.push(url);
+        return new Promise((resolve, reject) => {
+          resolvePromise = resolve;
+          rejectPromise = reject;
+        });
+      });
+      return {
+        mockFn,
+        calls,
+        resolve: (data = []) => resolvePromise({
+          ok: true,
+          json: async () => data,
+          text: async () => JSON.stringify(data),
+        }),
+        reject: (err) => rejectPromise(err),
+        resolveError: (status = 500, body = '{"error":"Server error"}') => resolvePromise({
+          ok: false,
+          status,
+          json: async () => JSON.parse(body),
+          text: async () => body,
+        }),
+      };
+    }
+
+    /**
+     * Property 2a: Loading is true during fetch on successful completion
+     * (Req 3.5, 3.6) - loading=true when fetch begins, loading=false after success
+     */
+    it('2a: loading is true during fetch and false after successful completion', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.array(
+            fc.record({
+              id: fc.integer({ min: 1, max: 10000 }),
+              date: fc.constant('2024-01-15'),
+              place: fc.string({ minLength: 1, maxLength: 20 }),
+              amount: fc.float({ min: Math.fround(0.01), max: Math.fround(10000), noNaN: true }),
+              type: fc.constant('Groceries'),
+              method: fc.constant('Cash'),
+            }),
+            { minLength: 0, maxLength: 5 }
+          ),
+          async (year, month, expenseData) => {
+            cleanup();
+
+            // Start with a quick-resolving fetch for the initial mount
+            const initialFetch = createMockFetch();
+            globalThis.fetch = initialFetch.mockFn;
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Now set up a deferred fetch so we can observe loading=true
+            const deferred = createDeferredFetch();
+            globalThis.fetch = deferred.mockFn;
+
+            // Trigger a re-fetch by changing month
+            act(() => {
+              result.current.filter.handleMonthChange(year, month);
+            });
+
+            // Loading should be true while fetch is in progress
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(true);
+            });
+
+            // Resolve the fetch with expense data
+            await act(async () => {
+              deferred.resolve(expenseData);
+            });
+
+            // Loading should be false after successful completion
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Error should be null on success
+            expect(result.current.expense.error).toBeNull();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 2b: Loading is true during fetch and false after server error
+     * (Req 3.5, 3.8) - loading=true when fetch begins, loading=false after server error
+     */
+    it('2b: loading is true during fetch and false after server error', { timeout: 60000 }, async () => {
+      // Suppress console.error for expected error logging
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await fc.assert(
+          fc.asyncProperty(
+            fc.integer({ min: 2000, max: 2100 }),
+            fc.integer({ min: 1, max: 12 }),
+            fc.constantFrom(400, 404, 500, 502, 503),
+            fc.string({ minLength: 1, maxLength: 50 }),
+            async (year, month, statusCode, errorMsg) => {
+              cleanup();
+
+              // Start with a quick-resolving fetch for the initial mount
+              const initialFetch = createMockFetch();
+              globalThis.fetch = initialFetch.mockFn;
+
+              const { result } = renderHook(() => useBothContexts(), {
+                wrapper: ({ children }) => (
+                  <FilterProvider>
+                    <ExpenseProvider>{children}</ExpenseProvider>
+                  </FilterProvider>
+                ),
+              });
+
+              // Wait for initial fetch to complete
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(false);
+              });
+
+              // Now set up a deferred fetch so we can observe loading=true
+              const deferred = createDeferredFetch();
+              globalThis.fetch = deferred.mockFn;
+
+              // Trigger a re-fetch by changing month
+              act(() => {
+                result.current.filter.handleMonthChange(year, month);
+              });
+
+              // Loading should be true while fetch is in progress
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(true);
+              });
+
+              // Resolve with a server error
+              await act(async () => {
+                deferred.resolveError(statusCode, JSON.stringify({ error: errorMsg }));
+              });
+
+              // Loading should be false after error
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(false);
+              });
+
+              // Error should be set (non-null)
+              expect(result.current.expense.error).toBeTruthy();
+            }
+          ),
+          { numRuns: 100 }
+        );
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
+    /**
+     * Property 2c: Loading is true during fetch and false after network error
+     * (Req 3.5, 3.7) - loading=true when fetch begins, loading=false after network failure
+     */
+    it('2c: loading is true during fetch and false after network error', { timeout: 60000 }, async () => {
+      // Suppress console.error for expected error logging
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await fc.assert(
+          fc.asyncProperty(
+            fc.integer({ min: 2000, max: 2100 }),
+            fc.integer({ min: 1, max: 12 }),
+            fc.constantFrom('Failed to fetch', 'NetworkError when attempting to fetch resource', 'fetch failed'),
+            async (year, month, networkErrorMsg) => {
+              cleanup();
+
+              // Start with a quick-resolving fetch for the initial mount
+              const initialFetch = createMockFetch();
+              globalThis.fetch = initialFetch.mockFn;
+
+              const { result } = renderHook(() => useBothContexts(), {
+                wrapper: ({ children }) => (
+                  <FilterProvider>
+                    <ExpenseProvider>{children}</ExpenseProvider>
+                  </FilterProvider>
+                ),
+              });
+
+              // Wait for initial fetch to complete
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(false);
+              });
+
+              // Now set up a deferred fetch so we can observe loading=true
+              const deferred = createDeferredFetch();
+              globalThis.fetch = deferred.mockFn;
+
+              // Trigger a re-fetch by changing month
+              act(() => {
+                result.current.filter.handleMonthChange(year, month);
+              });
+
+              // Loading should be true while fetch is in progress
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(true);
+              });
+
+              // Reject with a network error
+              await act(async () => {
+                deferred.reject(new TypeError(networkErrorMsg));
+              });
+
+              // Loading should be false after network error
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(false);
+              });
+
+              // Error should be set to the user-friendly network error message
+              expect(result.current.expense.error).toBe(
+                'Unable to connect to the server. Please check your connection and try again.'
+              );
+            }
+          ),
+          { numRuns: 100 }
+        );
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
+    /**
+     * Property 2d: Loading transitions correctly across consecutive fetches
+     * (Req 3.5, 3.6) - Each fetch cycle independently transitions loading true→false
+     */
+    it('2d: loading transitions correctly across consecutive view mode changes', { timeout: 120000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          async (year1, month1, year2, month2) => {
+            cleanup();
+
+            // Start with a quick-resolving fetch for the initial mount
+            const initialFetch = createMockFetch();
+            globalThis.fetch = initialFetch.mockFn;
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // First fetch cycle: deferred
+            const deferred1 = createDeferredFetch();
+            globalThis.fetch = deferred1.mockFn;
+
+            act(() => {
+              result.current.filter.handleMonthChange(year1, month1);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(true);
+            });
+
+            await act(async () => {
+              deferred1.resolve([{ id: 1, date: `${year1}-${String(month1).padStart(2, '0')}-15`, place: 'Test', amount: 10, type: 'Groceries', method: 'Cash' }]);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Second fetch cycle: deferred
+            const deferred2 = createDeferredFetch();
+            globalThis.fetch = deferred2.mockFn;
+
+            act(() => {
+              result.current.filter.handleMonthChange(year2, month2);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(true);
+            });
+
+            await act(async () => {
+              deferred2.resolve([]);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // After both cycles, loading should be false and no error
+            expect(result.current.expense.loading).toBe(false);
+            expect(result.current.expense.error).toBeNull();
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 3: handleExpenseAdded inserts in date-sorted order**
+   *
+   * For any expenses array and any new expense whose date falls within the current view
+   * (matching year/month in monthly view, or any date in global view), calling
+   * handleExpenseAdded SHALL result in the expenses array containing the new expense
+   * and being sorted by date ascending.
+   *
+   * **Validates: Requirements 4.1**
+   */
+  describe('Property 3: handleExpenseAdded inserts in date-sorted order', () => {
+    // Helper: check if an array of expenses is sorted by date ascending
+    function isSortedByDate(arr) {
+      for (let i = 1; i < arr.length; i++) {
+        if (new Date(arr[i].date) < new Date(arr[i - 1].date)) return false;
+      }
+      return true;
+    }
+
+    // Helper: generate a YYYY-MM-DD date string
+    function makeDate(year, month, day) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+
+    /**
+     * Property 3a: In monthly view, adding an expense with matching year/month
+     * results in a date-sorted array containing the new expense.
+     */
+    it('3a: monthly view - new expense with matching date is inserted in sorted order', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 0, max: 10 }),
+          fc.integer({ min: 1, max: 28 }),
+          async (year, month, existingCount, newDay) => {
+            cleanup();
+
+            // Build existing expenses for this year/month with unique IDs
+            const existing = [];
+            for (let i = 0; i < existingCount; i++) {
+              const day = (i % 28) + 1;
+              existing.push({
+                id: i + 1,
+                date: makeDate(year, month, day),
+                place: `Place${i}`,
+                notes: null,
+                amount: 10 + i,
+                type: 'Groceries',
+                method: 'Cash',
+                week: 1,
+              });
+            }
+            existing.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            const newExpense = {
+              id: existingCount + 100,
+              date: makeDate(year, month, newDay),
+              place: 'NewPlace',
+              notes: null,
+              amount: 50,
+              type: 'Dining Out',
+              method: 'Debit',
+              week: 1,
+            };
+
+            // Mock fetch to return the existing expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => existing,
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set the view to the matching year/month
+            act(() => {
+              result.current.filter.handleMonthChange(year, month);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in monthly view
+            expect(result.current.filter.isGlobalView).toBe(false);
+
+            // Call handleExpenseAdded with the new expense
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify the new expense is in the array
+            const expenseIds = result.current.expense.expenses.map(e => e.id);
+            expect(expenseIds).toContain(newExpense.id);
+
+            // Verify the array is sorted by date ascending
+            expect(isSortedByDate(result.current.expense.expenses)).toBe(true);
+
+            // Verify the array length increased by 1
+            expect(result.current.expense.expenses.length).toBe(existing.length + 1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 3b: In global view, adding any expense results in a date-sorted
+     * array containing the new expense.
+     */
+    it('3b: global view - new expense is inserted in sorted order', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 0, max: 10 }),
+          fc.integer({ min: 2020, max: 2025 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 28 }),
+          async (existingCount, newYear, newMonth, newDay) => {
+            cleanup();
+
+            // Build existing expenses across various dates
+            const existing = [];
+            for (let i = 0; i < existingCount; i++) {
+              const y = 2020 + (i % 6);
+              const m = (i % 12) + 1;
+              const d = (i % 28) + 1;
+              existing.push({
+                id: i + 1,
+                date: makeDate(y, m, d),
+                place: `Place${i}`,
+                notes: null,
+                amount: 10 + i,
+                type: 'Groceries',
+                method: 'Cash',
+                week: 1,
+              });
+            }
+            existing.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            const newExpense = {
+              id: existingCount + 200,
+              date: makeDate(newYear, newMonth, newDay),
+              place: 'GlobalNewPlace',
+              notes: null,
+              amount: 75,
+              type: 'Entertainment',
+              method: 'Credit Card',
+              week: 1,
+            };
+
+            // Mock fetch to return the existing expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => existing,
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Switch to global view by setting a filter year
+            act(() => {
+              result.current.filter.handleFilterYearChange('2023');
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in global view
+            expect(result.current.filter.isGlobalView).toBe(true);
+
+            // Call handleExpenseAdded with the new expense
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify the new expense is in the array
+            const expenseIds = result.current.expense.expenses.map(e => e.id);
+            expect(expenseIds).toContain(newExpense.id);
+
+            // Verify the array is sorted by date ascending
+            expect(isSortedByDate(result.current.expense.expenses)).toBe(true);
+
+            // Verify the array length increased by 1
+            expect(result.current.expense.expenses.length).toBe(existing.length + 1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 3c: Adding an expense to an already-sorted array preserves sort order
+     * regardless of where the new expense's date falls (beginning, middle, or end).
+     */
+    it('3c: new expense date at any position maintains sorted order', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.constantFrom('beginning', 'middle', 'end'),
+          fc.integer({ min: 1, max: 8 }),
+          async (year, month, position, existingCount) => {
+            cleanup();
+
+            // Create existing expenses spread across the month
+            const existing = [];
+            for (let i = 0; i < existingCount; i++) {
+              const day = Math.min(28, Math.max(1, Math.floor((i + 1) * 28 / (existingCount + 1))));
+              existing.push({
+                id: i + 1,
+                date: makeDate(year, month, day),
+                place: `Place${i}`,
+                notes: null,
+                amount: 10 + i,
+                type: 'Groceries',
+                method: 'Cash',
+                week: 1,
+              });
+            }
+            existing.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            // Create new expense at the specified position
+            let newDay;
+            if (position === 'beginning') {
+              newDay = 1;
+            } else if (position === 'end') {
+              newDay = 28;
+            } else {
+              newDay = 14;
+            }
+
+            const newExpense = {
+              id: 999,
+              date: makeDate(year, month, newDay),
+              place: 'InsertedPlace',
+              notes: null,
+              amount: 50,
+              type: 'Dining Out',
+              method: 'Debit',
+              week: 1,
+            };
+
+            // Mock fetch to return the existing expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => existing,
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set the view to the matching year/month
+            act(() => {
+              result.current.filter.handleMonthChange(year, month);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Call handleExpenseAdded
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify the new expense is in the array
+            expect(result.current.expense.expenses.map(e => e.id)).toContain(999);
+
+            // Verify sorted order
+            expect(isSortedByDate(result.current.expense.expenses)).toBe(true);
+
+            // Verify length
+            expect(result.current.expense.expenses.length).toBe(existing.length + 1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 4: handleExpenseAdded skips out-of-view expenses**
+   *
+   * For any new expense whose year/month does not match the selected year/month
+   * while in monthly view, calling handleExpenseAdded SHALL not change the
+   * expenses array length.
+   *
+   * **Validates: Requirements 4.2**
+   */
+  describe('Property 4: handleExpenseAdded skips out-of-view expenses', () => {
+    // Helper: generate a YYYY-MM-DD date string
+    function makeDate(year, month, day) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+
+    /**
+     * Property 4a: In monthly view, adding an expense with a different year/month
+     * does NOT add it to the expenses array (length unchanged).
+     * Uses a smart generator that ensures the expense year/month differs from the selected view.
+     */
+    it('4a: monthly view - expense with mismatched year/month is not added', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 28 }),
+          fc.integer({ min: 0, max: 10 }),
+          async (selectedYear, selectedMonth, expYear, expMonth, expDay, existingCount) => {
+            // Pre-condition: expense year/month must NOT match selected year/month
+            fc.pre(expYear !== selectedYear || expMonth !== selectedMonth);
+
+            cleanup();
+
+            // Build existing expenses for the selected year/month
+            const existing = [];
+            for (let i = 0; i < existingCount; i++) {
+              const day = (i % 28) + 1;
+              existing.push({
+                id: i + 1,
+                date: makeDate(selectedYear, selectedMonth, day),
+                place: `Place${i}`,
+                notes: null,
+                amount: 10 + i,
+                type: 'Groceries',
+                method: 'Cash',
+                week: 1,
+              });
+            }
+            existing.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            // Mock fetch to return the existing expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => existing,
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set the view to the selected year/month (monthly view)
+            act(() => {
+              result.current.filter.handleMonthChange(selectedYear, selectedMonth);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in monthly view
+            expect(result.current.filter.isGlobalView).toBe(false);
+
+            // Record the current expenses length
+            const lengthBefore = result.current.expense.expenses.length;
+
+            const newExpense = {
+              id: existingCount + 500,
+              date: makeDate(expYear, expMonth, expDay),
+              place: 'OutOfViewPlace',
+              notes: null,
+              amount: 99,
+              type: 'Entertainment',
+              method: 'Debit',
+              week: 2,
+            };
+
+            // Call handleExpenseAdded with the out-of-view expense
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify the expenses array length is unchanged
+            expect(result.current.expense.expenses.length).toBe(lengthBefore);
+
+            // Verify the new expense is NOT in the array
+            const expenseIds = result.current.expense.expenses.map(e => e.id);
+            expect(expenseIds).not.toContain(newExpense.id);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 4b: In monthly view, expense with different year (same month) is skipped.
+     */
+    it('4b: monthly view - expense with different year but same month is not added', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2001, max: 2099 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 28 }),
+          fc.integer({ min: 0, max: 5 }),
+          async (selectedYear, selectedMonth, newDay, existingCount) => {
+            cleanup();
+
+            // Build existing expenses for the selected year/month
+            const existing = [];
+            for (let i = 0; i < existingCount; i++) {
+              const day = (i % 28) + 1;
+              existing.push({
+                id: i + 1,
+                date: makeDate(selectedYear, selectedMonth, day),
+                place: `Place${i}`,
+                notes: null,
+                amount: 10 + i,
+                type: 'Groceries',
+                method: 'Cash',
+                week: 1,
+              });
+            }
+            existing.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            // Mock fetch to return the existing expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => existing,
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set the view to the selected year/month (monthly view)
+            act(() => {
+              result.current.filter.handleMonthChange(selectedYear, selectedMonth);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in monthly view
+            expect(result.current.filter.isGlobalView).toBe(false);
+
+            const lengthBefore = result.current.expense.expenses.length;
+
+            // Use a different year (offset by 1) but same month
+            const differentYear = selectedYear + 1;
+
+            const newExpense = {
+              id: existingCount + 600,
+              date: makeDate(differentYear, selectedMonth, newDay),
+              place: 'DiffYearPlace',
+              notes: null,
+              amount: 42,
+              type: 'Dining Out',
+              method: 'Cash',
+              week: 1,
+            };
+
+            // Call handleExpenseAdded with the out-of-view expense
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify the expenses array length is unchanged
+            expect(result.current.expense.expenses.length).toBe(lengthBefore);
+
+            // Verify the new expense is NOT in the array
+            expect(result.current.expense.expenses.map(e => e.id)).not.toContain(newExpense.id);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 4c: In monthly view, expense with different month (same year) is skipped.
+     */
+    it('4c: monthly view - expense with same year but different month is not added', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2000, max: 2100 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 28 }),
+          fc.integer({ min: 0, max: 5 }),
+          async (selectedYear, selectedMonth, newDay, existingCount) => {
+            cleanup();
+
+            // Build existing expenses for the selected year/month
+            const existing = [];
+            for (let i = 0; i < existingCount; i++) {
+              const day = (i % 28) + 1;
+              existing.push({
+                id: i + 1,
+                date: makeDate(selectedYear, selectedMonth, day),
+                place: `Place${i}`,
+                notes: null,
+                amount: 10 + i,
+                type: 'Groceries',
+                method: 'Cash',
+                week: 1,
+              });
+            }
+            existing.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            // Mock fetch to return the existing expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => existing,
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set the view to the selected year/month (monthly view)
+            act(() => {
+              result.current.filter.handleMonthChange(selectedYear, selectedMonth);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify we're in monthly view
+            expect(result.current.filter.isGlobalView).toBe(false);
+
+            const lengthBefore = result.current.expense.expenses.length;
+
+            // Use a different month (wrap around) but same year
+            const differentMonth = (selectedMonth % 12) + 1;
+
+            const newExpense = {
+              id: existingCount + 700,
+              date: makeDate(selectedYear, differentMonth, newDay),
+              place: 'DiffMonthPlace',
+              notes: null,
+              amount: 33,
+              type: 'Utilities',
+              method: 'Debit',
+              week: 1,
+            };
+
+            // Call handleExpenseAdded with the out-of-view expense
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify the expenses array length is unchanged
+            expect(result.current.expense.expenses.length).toBe(lengthBefore);
+
+            // Verify the new expense is NOT in the array
+            expect(result.current.expense.expenses.map(e => e.id)).not.toContain(newExpense.id);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 4d: refreshTrigger still increments even when expense is skipped.
+     * (Req 4.3) - handleExpenseAdded always increments refreshTrigger regardless of view match.
+     */
+    it('4d: refreshTrigger increments even when expense is out of view', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2001, max: 2099 }),
+          fc.integer({ min: 1, max: 12 }),
+          async (selectedYear, selectedMonth) => {
+            cleanup();
+
+            // Mock fetch to return empty array
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [],
+              text: async () => '[]',
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Set the view to the selected year/month (monthly view)
+            act(() => {
+              result.current.filter.handleMonthChange(selectedYear, selectedMonth);
+            });
+
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Record refreshTrigger before
+            const refreshBefore = result.current.expense.refreshTrigger;
+
+            // Create an out-of-view expense (different year)
+            const newExpense = {
+              id: 999,
+              date: makeDate(selectedYear + 1, selectedMonth, 15),
+              place: 'OutOfView',
+              notes: null,
+              amount: 50,
+              type: 'Groceries',
+              method: 'Cash',
+              week: 2,
+            };
+
+            // Call handleExpenseAdded
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify refreshTrigger incremented by 1
+            expect(result.current.expense.refreshTrigger).toBe(refreshBefore + 1);
+
+            // But expenses array should still be empty
+            expect(result.current.expense.expenses.length).toBe(0);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 5: handleExpenseDeleted removes exactly the target expense**
+   *
+   * For any expenses array with unique IDs and any valid expense ID in that array,
+   * calling handleExpenseDeleted SHALL result in an array with length reduced by 1,
+   * containing all original expenses except the one with the deleted ID.
+   *
+   * **Validates: Requirements 4.4**
+   */
+  describe('Property 5: handleExpenseDeleted removes exactly the target expense', () => {
+    // Helper: generate a YYYY-MM-DD date string
+    function makeDate(year, month, day) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+
+    // Arbitrary: generate an array of expenses with unique IDs
+    const expenseArrayArb = (minLen, maxLen) =>
+      fc.integer({ min: minLen, max: maxLen }).chain(count =>
+        fc.tuple(
+          fc.uniqueArray(fc.integer({ min: 1, max: 100000 }), { minLength: count, maxLength: count }),
+          fc.array(fc.integer({ min: 1, max: 28 }), { minLength: count, maxLength: count }),
+          fc.array(
+            fc.constantFrom('Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities'),
+            { minLength: count, maxLength: count }
+          ),
+          fc.array(
+            fc.constantFrom('Cash', 'Debit', 'Credit Card'),
+            { minLength: count, maxLength: count }
+          ),
+        ).map(([ids, days, types, methods]) =>
+          ids.map((id, i) => ({
+            id,
+            date: makeDate(2024, 6, days[i]),
+            place: `Place${id}`,
+            notes: i % 2 === 0 ? `Note${id}` : null,
+            amount: 10 + i,
+            type: types[i],
+            method: methods[i],
+            week: 1,
+          }))
+        )
+      );
+
+    /**
+     * Property 5a: Deleting a random expense from the array reduces length by exactly 1
+     * and the deleted ID is absent from the result.
+     */
+    it('5a: deleting an expense reduces length by 1 and removes the target ID', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 20),
+          async (expenses) => {
+            cleanup();
+
+            // Pick a random expense ID to delete from the generated array
+            const targetIndex = Math.floor(Math.random() * expenses.length);
+            const targetId = expenses[targetIndex].id;
+
+            // Mock fetch to return the expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify expenses loaded
+            expect(result.current.expense.expenses.length).toBe(expenses.length);
+
+            // Call handleExpenseDeleted with the target ID
+            act(() => {
+              result.current.expense.handleExpenseDeleted(targetId);
+            });
+
+            // Verify length reduced by exactly 1
+            expect(result.current.expense.expenses.length).toBe(expenses.length - 1);
+
+            // Verify the deleted ID is absent
+            const remainingIds = result.current.expense.expenses.map(e => e.id);
+            expect(remainingIds).not.toContain(targetId);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 5b: All non-deleted expenses remain unchanged after deletion.
+     * Every expense that was NOT deleted should still be present with identical data.
+     */
+    it('5b: all non-deleted expenses remain unchanged after deletion', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 20),
+          async (expenses) => {
+            cleanup();
+
+            // Pick a random expense ID to delete
+            const targetIndex = Math.floor(Math.random() * expenses.length);
+            const targetId = expenses[targetIndex].id;
+
+            // Build the expected remaining expenses (all except the deleted one)
+            const expectedRemaining = expenses.filter(e => e.id !== targetId);
+
+            // Mock fetch to return the expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Call handleExpenseDeleted
+            act(() => {
+              result.current.expense.handleExpenseDeleted(targetId);
+            });
+
+            // Verify each remaining expense matches the expected data
+            const remaining = result.current.expense.expenses;
+            expect(remaining.length).toBe(expectedRemaining.length);
+
+            for (const expected of expectedRemaining) {
+              const found = remaining.find(e => e.id === expected.id);
+              expect(found).toBeDefined();
+              expect(found.date).toBe(expected.date);
+              expect(found.place).toBe(expected.place);
+              expect(found.amount).toBe(expected.amount);
+              expect(found.type).toBe(expected.type);
+              expect(found.method).toBe(expected.method);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 5c: Deleting from a single-element array results in an empty array.
+     * Edge case: when there's only one expense and it's deleted.
+     */
+    it('5c: deleting the only expense results in an empty array', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 100000 }),
+          fc.integer({ min: 1, max: 28 }),
+          async (expenseId, day) => {
+            cleanup();
+
+            const singleExpense = [{
+              id: expenseId,
+              date: makeDate(2024, 6, day),
+              place: `Place${expenseId}`,
+              notes: null,
+              amount: 25,
+              type: 'Groceries',
+              method: 'Cash',
+              week: 1,
+            }];
+
+            // Mock fetch to return the single expense
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...singleExpense],
+              text: async () => JSON.stringify(singleExpense),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify single expense loaded
+            expect(result.current.expense.expenses.length).toBe(1);
+
+            // Delete the only expense
+            act(() => {
+              result.current.expense.handleExpenseDeleted(expenseId);
+            });
+
+            // Verify array is now empty
+            expect(result.current.expense.expenses.length).toBe(0);
+            expect(result.current.expense.expenses).toEqual([]);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 6: handleExpenseUpdated replaces the matching expense**
+   *
+   * For any expenses array and any updated expense object whose ID matches an expense
+   * in the array, calling handleExpenseUpdated SHALL result in the array containing
+   * the updated expense at the same position, with all other expenses unchanged.
+   *
+   * **Validates: Requirements 4.6**
+   */
+  describe('Property 6: handleExpenseUpdated replaces the matching expense', () => {
+    // Helper: generate a YYYY-MM-DD date string
+    function makeDate(year, month, day) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+
+    // Arbitrary: generate an array of expenses with unique IDs
+    const expenseArrayArb = (minLen, maxLen) =>
+      fc.integer({ min: minLen, max: maxLen }).chain(count =>
+        fc.tuple(
+          fc.uniqueArray(fc.integer({ min: 1, max: 100000 }), { minLength: count, maxLength: count }),
+          fc.array(fc.integer({ min: 1, max: 28 }), { minLength: count, maxLength: count }),
+          fc.array(
+            fc.constantFrom('Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities'),
+            { minLength: count, maxLength: count }
+          ),
+          fc.array(
+            fc.constantFrom('Cash', 'Debit', 'Credit Card'),
+            { minLength: count, maxLength: count }
+          ),
+          fc.array(
+            fc.float({ min: Math.fround(0.01), max: Math.fround(10000), noNaN: true }),
+            { minLength: count, maxLength: count }
+          ),
+        ).map(([ids, days, types, methods, amounts]) =>
+          ids.map((id, i) => ({
+            id,
+            date: makeDate(2024, 6, days[i]),
+            place: `Place${id}`,
+            notes: i % 2 === 0 ? `Note${id}` : null,
+            amount: amounts[i],
+            type: types[i],
+            method: methods[i],
+            week: 1,
+          }))
+        )
+      );
+
+    /**
+     * Property 6a: Updating a random expense replaces it in the array with the
+     * updated data, array length stays the same, and all other expenses are unchanged.
+     */
+    it('6a: updating an expense replaces it at the same position with all others unchanged', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 20),
+          fc.constantFrom('Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities'),
+          fc.constantFrom('Cash', 'Debit', 'Credit Card'),
+          fc.float({ min: Math.fround(0.01), max: Math.fround(10000), noNaN: true }),
+          fc.integer({ min: 1, max: 28 }),
+          async (expenses, newType, newMethod, newAmount, newDay) => {
+            cleanup();
+
+            // Pick a random expense to update
+            const targetIndex = Math.floor(Math.random() * expenses.length);
+            const targetId = expenses[targetIndex].id;
+
+            // Create the updated expense with the same ID but different fields
+            const updatedExpense = {
+              ...expenses[targetIndex],
+              place: 'UpdatedPlace',
+              notes: 'Updated notes',
+              amount: newAmount,
+              type: newType,
+              method: newMethod,
+              date: makeDate(2024, 6, newDay),
+            };
+
+            // Mock fetch to return the expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify expenses loaded
+            expect(result.current.expense.expenses.length).toBe(expenses.length);
+
+            // Call handleExpenseUpdated
+            act(() => {
+              result.current.expense.handleExpenseUpdated(updatedExpense);
+            });
+
+            const resultExpenses = result.current.expense.expenses;
+
+            // Verify array length is unchanged
+            expect(resultExpenses.length).toBe(expenses.length);
+
+            // Verify the updated expense is in the array with the new data
+            const found = resultExpenses.find(e => e.id === targetId);
+            expect(found).toBeDefined();
+            expect(found.place).toBe('UpdatedPlace');
+            expect(found.notes).toBe('Updated notes');
+            expect(found.amount).toBe(newAmount);
+            expect(found.type).toBe(newType);
+            expect(found.method).toBe(newMethod);
+            expect(found.date).toBe(makeDate(2024, 6, newDay));
+
+            // Verify all other expenses are unchanged
+            for (let i = 0; i < expenses.length; i++) {
+              if (expenses[i].id !== targetId) {
+                const original = expenses[i];
+                const current = resultExpenses.find(e => e.id === original.id);
+                expect(current).toBeDefined();
+                expect(current.date).toBe(original.date);
+                expect(current.place).toBe(original.place);
+                expect(current.notes).toBe(original.notes);
+                expect(current.amount).toBe(original.amount);
+                expect(current.type).toBe(original.type);
+                expect(current.method).toBe(original.method);
+              }
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 6b: The updated expense appears at the same index position as the original.
+     * handleExpenseUpdated uses .map(), so position is preserved.
+     */
+    it('6b: updated expense maintains the same index position in the array', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 20),
+          async (expenses) => {
+            cleanup();
+
+            // Pick a random expense to update
+            const targetIndex = Math.floor(Math.random() * expenses.length);
+            const targetId = expenses[targetIndex].id;
+
+            // Create the updated expense
+            const updatedExpense = {
+              ...expenses[targetIndex],
+              place: 'PositionTestPlace',
+              amount: 999.99,
+            };
+
+            // Mock fetch to return the expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Record the original order of IDs
+            const originalIds = result.current.expense.expenses.map(e => e.id);
+
+            // Call handleExpenseUpdated
+            act(() => {
+              result.current.expense.handleExpenseUpdated(updatedExpense);
+            });
+
+            // Verify the order of IDs is preserved (same positions)
+            const updatedIds = result.current.expense.expenses.map(e => e.id);
+            expect(updatedIds).toEqual(originalIds);
+
+            // Verify the updated expense is at the same index
+            const updatedAtIndex = result.current.expense.expenses[targetIndex];
+            expect(updatedAtIndex.id).toBe(targetId);
+            expect(updatedAtIndex.place).toBe('PositionTestPlace');
+            expect(updatedAtIndex.amount).toBe(999.99);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 6c: Updating the only expense in a single-element array replaces it correctly.
+     * Edge case: array has exactly one expense.
+     */
+    it('6c: updating the only expense in a single-element array replaces it correctly', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 100000 }),
+          fc.integer({ min: 1, max: 28 }),
+          fc.constantFrom('Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities'),
+          fc.constantFrom('Cash', 'Debit', 'Credit Card'),
+          fc.float({ min: Math.fround(0.01), max: Math.fround(10000), noNaN: true }),
+          async (expenseId, day, newType, newMethod, newAmount) => {
+            cleanup();
+
+            const singleExpense = [{
+              id: expenseId,
+              date: makeDate(2024, 6, day),
+              place: `OriginalPlace`,
+              notes: 'Original notes',
+              amount: 50,
+              type: 'Groceries',
+              method: 'Cash',
+              week: 1,
+            }];
+
+            const updatedExpense = {
+              id: expenseId,
+              date: makeDate(2024, 6, day),
+              place: 'SingleUpdatedPlace',
+              notes: 'Updated single notes',
+              amount: newAmount,
+              type: newType,
+              method: newMethod,
+              week: 1,
+            };
+
+            // Mock fetch to return the single expense
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...singleExpense],
+              text: async () => JSON.stringify(singleExpense),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Verify single expense loaded
+            expect(result.current.expense.expenses.length).toBe(1);
+
+            // Update the only expense
+            act(() => {
+              result.current.expense.handleExpenseUpdated(updatedExpense);
+            });
+
+            // Verify array still has exactly 1 element
+            expect(result.current.expense.expenses.length).toBe(1);
+
+            // Verify it's the updated expense
+            const resultExpense = result.current.expense.expenses[0];
+            expect(resultExpense.id).toBe(expenseId);
+            expect(resultExpense.place).toBe('SingleUpdatedPlace');
+            expect(resultExpense.notes).toBe('Updated single notes');
+            expect(resultExpense.amount).toBe(newAmount);
+            expect(resultExpense.type).toBe(newType);
+            expect(resultExpense.method).toBe(newMethod);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 7: CRUD operations increment refreshTrigger**
+   *
+   * For any CRUD operation (add, delete, update), the refreshTrigger SHALL increase
+   * by exactly 1 after the operation completes.
+   *
+   * **Validates: Requirements 4.3, 4.5, 4.7**
+   */
+  describe('Property 7: CRUD operations increment refreshTrigger', () => {
+    // Helper: generate a YYYY-MM-DD date string
+    function makeDate(year, month, day) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+
+    // Arbitrary: generate an array of expenses with unique IDs for a fixed year/month
+    const expenseArrayArb = (minLen, maxLen) =>
+      fc.integer({ min: minLen, max: maxLen }).chain(count =>
+        fc.tuple(
+          fc.uniqueArray(fc.integer({ min: 1, max: 100000 }), { minLength: count, maxLength: count }),
+          fc.array(fc.integer({ min: 1, max: 28 }), { minLength: count, maxLength: count }),
+          fc.array(
+            fc.constantFrom('Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities'),
+            { minLength: count, maxLength: count }
+          ),
+          fc.array(
+            fc.constantFrom('Cash', 'Debit', 'Credit Card'),
+            { minLength: count, maxLength: count }
+          ),
+        ).map(([ids, days, types, methods]) =>
+          ids.map((id, i) => ({
+            id,
+            date: makeDate(2024, 6, days[i]),
+            place: `Place${id}`,
+            notes: i % 2 === 0 ? `Note${id}` : null,
+            amount: 10 + i,
+            type: types[i],
+            method: methods[i],
+            week: 1,
+          }))
+        )
+      );
+
+    /**
+     * Property 7a: handleExpenseAdded increments refreshTrigger by exactly 1
+     * (Req 4.3) - Each add operation increases refreshTrigger by 1
+     */
+    it('7a: handleExpenseAdded increments refreshTrigger by exactly 1', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 28 }),
+          fc.integer({ min: 100000, max: 200000 }),
+          async (day, newId) => {
+            cleanup();
+
+            // Mock fetch to return empty array
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [],
+              text: async () => '[]',
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Record refreshTrigger before the operation
+            const refreshBefore = result.current.expense.refreshTrigger;
+
+            // Create a new expense matching the current view (default is current year/month)
+            const now = new Date();
+            const newExpense = {
+              id: newId,
+              date: makeDate(now.getFullYear(), now.getMonth() + 1, day),
+              place: 'AddedPlace',
+              notes: null,
+              amount: 50,
+              type: 'Groceries',
+              method: 'Cash',
+              week: 1,
+            };
+
+            // Call handleExpenseAdded
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            // Verify refreshTrigger incremented by exactly 1
+            expect(result.current.expense.refreshTrigger).toBe(refreshBefore + 1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 7b: handleExpenseDeleted increments refreshTrigger by exactly 1
+     * (Req 4.5) - Each delete operation increases refreshTrigger by 1
+     */
+    it('7b: handleExpenseDeleted increments refreshTrigger by exactly 1', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          async (expenses) => {
+            cleanup();
+
+            // Mock fetch to return the expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Pick a random expense ID to delete
+            const targetIndex = Math.floor(Math.random() * expenses.length);
+            const targetId = expenses[targetIndex].id;
+
+            // Record refreshTrigger before the operation
+            const refreshBefore = result.current.expense.refreshTrigger;
+
+            // Call handleExpenseDeleted
+            act(() => {
+              result.current.expense.handleExpenseDeleted(targetId);
+            });
+
+            // Verify refreshTrigger incremented by exactly 1
+            expect(result.current.expense.refreshTrigger).toBe(refreshBefore + 1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 7c: handleExpenseUpdated increments refreshTrigger by exactly 1
+     * (Req 4.7) - Each update operation increases refreshTrigger by 1
+     */
+    it('7c: handleExpenseUpdated increments refreshTrigger by exactly 1', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          fc.constantFrom('Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities'),
+          fc.float({ min: Math.fround(0.01), max: Math.fround(10000), noNaN: true }),
+          async (expenses, newType, newAmount) => {
+            cleanup();
+
+            // Mock fetch to return the expenses
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Pick a random expense to update
+            const targetIndex = Math.floor(Math.random() * expenses.length);
+            const updatedExpense = {
+              ...expenses[targetIndex],
+              type: newType,
+              amount: newAmount,
+              place: 'UpdatedForRefreshTest',
+            };
+
+            // Record refreshTrigger before the operation
+            const refreshBefore = result.current.expense.refreshTrigger;
+
+            // Call handleExpenseUpdated
+            act(() => {
+              result.current.expense.handleExpenseUpdated(updatedExpense);
+            });
+
+            // Verify refreshTrigger incremented by exactly 1
+            expect(result.current.expense.refreshTrigger).toBe(refreshBefore + 1);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 7d: Sequential CRUD operations each increment refreshTrigger by 1
+     * Tests that multiple consecutive operations each independently increment the counter.
+     */
+    it('7d: sequential CRUD operations each increment refreshTrigger by 1', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 1, max: 28 }),
+          fc.integer({ min: 1, max: 28 }),
+          async (addDay, updateDay) => {
+            cleanup();
+
+            // Start with one existing expense
+            const existing = [{
+              id: 1,
+              date: makeDate(2024, 6, 15),
+              place: 'ExistingPlace',
+              notes: null,
+              amount: 25,
+              type: 'Groceries',
+              method: 'Cash',
+              week: 1,
+            }];
+
+            // Mock fetch to return the existing expense
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...existing],
+              text: async () => JSON.stringify(existing),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            const initialRefresh = result.current.expense.refreshTrigger;
+
+            // Operation 1: Add an expense (use current view's year/month)
+            const now = new Date();
+            const newExpense = {
+              id: 999,
+              date: makeDate(now.getFullYear(), now.getMonth() + 1, addDay),
+              place: 'SequentialAdd',
+              notes: null,
+              amount: 50,
+              type: 'Dining Out',
+              method: 'Debit',
+              week: 1,
+            };
+
+            act(() => {
+              result.current.expense.handleExpenseAdded(newExpense);
+            });
+
+            expect(result.current.expense.refreshTrigger).toBe(initialRefresh + 1);
+
+            // Operation 2: Update the existing expense
+            const updatedExpense = {
+              ...existing[0],
+              place: 'SequentialUpdate',
+              amount: 100,
+              date: makeDate(2024, 6, updateDay),
+            };
+
+            act(() => {
+              result.current.expense.handleExpenseUpdated(updatedExpense);
+            });
+
+            expect(result.current.expense.refreshTrigger).toBe(initialRefresh + 2);
+
+            // Operation 3: Delete the existing expense
+            act(() => {
+              result.current.expense.handleExpenseDeleted(1);
+            });
+
+            expect(result.current.expense.refreshTrigger).toBe(initialRefresh + 3);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  /**
+   * **Feature: expense-context, Property 8: Client-side filtering with AND logic**
+   *
+   * For any expenses array and any combination of filter values (searchText, filterType,
+   * filterMethod), filteredExpenses SHALL contain exactly the expenses where:
+   * - If searchText is non-empty: expense.place or expense.notes contains searchText (case-insensitive)
+   * - If filterType is non-empty: expense.type equals filterType
+   * - If filterMethod is non-empty: expense.method equals filterMethod
+   * - All active conditions are combined with AND logic
+   * - If no filters are active: filteredExpenses equals the full expenses array
+   *
+   * **Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6**
+   */
+  describe('Property 8: Client-side filtering with AND logic', () => {
+    // Helper: generate a YYYY-MM-DD date string
+    function makeDate(year, month, day) {
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    }
+
+    // Valid categories and methods for generators
+    const VALID_TYPES = ['Groceries', 'Dining Out', 'Entertainment', 'Gas', 'Utilities', 'Clothing', 'Housing'];
+    const VALID_METHODS = ['Cash', 'Debit', 'CIBC MC', 'PCF MC'];
+
+    // Arbitrary: generate an expense with controlled place, notes, type, method
+    const expenseArb = (id) =>
+      fc.record({
+        id: fc.constant(id),
+        date: fc.constant(makeDate(2024, 6, Math.min(28, Math.max(1, (id % 28) + 1)))),
+        place: fc.array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789'), { minLength: 1, maxLength: 20 }).map(a => a.join('')),
+        notes: fc.oneof(
+          fc.constant(null),
+          fc.array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789'), { minLength: 1, maxLength: 30 }).map(a => a.join(''))
+        ),
+        amount: fc.constant(10 + id),
+        type: fc.constantFrom(...VALID_TYPES),
+        method: fc.constantFrom(...VALID_METHODS),
+        week: fc.constant(1),
+      });
+
+    // Arbitrary: generate an array of expenses with unique sequential IDs
+    const expenseArrayArb = (minLen, maxLen) =>
+      fc.integer({ min: minLen, max: maxLen }).chain(count =>
+        count === 0
+          ? fc.constant([])
+          : fc.tuple(...Array.from({ length: count }, (_, i) => expenseArb(i + 1)))
+      );
+
+    // Reference implementation of the filtering logic (mirrors ExpenseContext)
+    function referenceFilter(expenses, searchText, filterType, filterMethod) {
+      return expenses.filter(expense => {
+        if (searchText) {
+          const searchLower = searchText.toLowerCase();
+          const placeMatch = expense.place && expense.place.toLowerCase().includes(searchLower);
+          const notesMatch = expense.notes && expense.notes.toLowerCase().includes(searchLower);
+          if (!placeMatch && !notesMatch) return false;
+        }
+        if (filterType && expense.type !== filterType) return false;
+        if (filterMethod && expense.method !== filterMethod) return false;
+        return true;
+      });
+    }
+
+    /**
+     * Property 8a: No filters returns the full expenses array
+     * (Req 5.6) - When no filters are active, filteredExpenses equals the full expenses array
+     */
+    it('8a: no filters returns the full expenses array', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(0, 15),
+          async (expenses) => {
+            cleanup();
+
+            // Mock fetch to return the expenses for any URL
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider paymentMethods={VALID_METHODS}>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // With no filters active, filteredExpenses should equal the full expenses array
+            expect(result.current.filter.searchText).toBe('');
+            expect(result.current.filter.filterType).toBe('');
+            expect(result.current.filter.filterMethod).toBe('');
+
+            expect(result.current.expense.filteredExpenses.length).toBe(expenses.length);
+            expect(result.current.expense.filteredExpenses.map(e => e.id)).toEqual(
+              result.current.expense.expenses.map(e => e.id)
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 8b: searchText filters case-insensitively on place and notes
+     * (Req 5.2) - searchText matches against place and notes fields case-insensitively
+     */
+    it('8b: searchText filters case-insensitively on place and notes', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          fc.array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789'), { minLength: 1, maxLength: 10 }).map(a => a.join('')),
+          async (expenses, searchText) => {
+            cleanup();
+
+            // Mock fetch to return the expenses for any URL (including global view)
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider paymentMethods={VALID_METHODS}>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Apply searchText filter (this triggers global view + re-fetch)
+            act(() => {
+              result.current.filter.handleSearchChange(searchText);
+            });
+
+            // Wait for re-fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Compute expected result using reference implementation
+            const expected = referenceFilter(expenses, searchText, '', '');
+
+            // Verify filteredExpenses matches reference
+            expect(result.current.expense.filteredExpenses.length).toBe(expected.length);
+            expect(result.current.expense.filteredExpenses.map(e => e.id)).toEqual(
+              expected.map(e => e.id)
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 8c: filterType filters by exact type match
+     * (Req 5.3) - filterType includes only expenses matching the selected category
+     */
+    it('8c: filterType filters by exact type match', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          fc.constantFrom(...VALID_TYPES),
+          async (expenses, filterType) => {
+            cleanup();
+
+            // Mock fetch to return the expenses for any URL
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider paymentMethods={VALID_METHODS}>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Apply filterType (does NOT trigger global view by itself)
+            act(() => {
+              result.current.filter.handleFilterTypeChange(filterType);
+            });
+
+            // Compute expected result using reference implementation
+            const expected = referenceFilter(expenses, '', filterType, '');
+
+            // Verify filteredExpenses matches reference
+            expect(result.current.expense.filteredExpenses.length).toBe(expected.length);
+            expect(result.current.expense.filteredExpenses.map(e => e.id)).toEqual(
+              expected.map(e => e.id)
+            );
+
+            // Verify all returned expenses have the correct type
+            for (const exp of result.current.expense.filteredExpenses) {
+              expect(exp.type).toBe(filterType);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 8d: filterMethod filters by exact method match
+     * (Req 5.4) - filterMethod includes only expenses matching the selected payment method
+     */
+    it('8d: filterMethod filters by exact method match', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          fc.constantFrom(...VALID_METHODS),
+          async (expenses, filterMethod) => {
+            cleanup();
+
+            // Mock fetch to return the expenses for any URL (including global view)
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider paymentMethods={VALID_METHODS}>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Apply filterMethod (triggers global view + re-fetch)
+            act(() => {
+              result.current.filter.handleFilterMethodChange(filterMethod);
+            });
+
+            // Wait for re-fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Compute expected result using reference implementation
+            const expected = referenceFilter(expenses, '', '', filterMethod);
+
+            // Verify filteredExpenses matches reference
+            expect(result.current.expense.filteredExpenses.length).toBe(expected.length);
+            expect(result.current.expense.filteredExpenses.map(e => e.id)).toEqual(
+              expected.map(e => e.id)
+            );
+
+            // Verify all returned expenses have the correct method
+            for (const exp of result.current.expense.filteredExpenses) {
+              expect(exp.method).toBe(filterMethod);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 8e: All filters combined with AND logic
+     * (Req 5.1, 5.5) - searchText + filterType + filterMethod all applied simultaneously
+     * An expense must match ALL active filters to be included.
+     */
+    it('8e: all filters combined with AND logic', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          fc.array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz'), { minLength: 1, maxLength: 5 }).map(a => a.join('')),
+          fc.constantFrom(...VALID_TYPES),
+          fc.constantFrom(...VALID_METHODS),
+          async (expenses, searchText, filterType, filterMethod) => {
+            cleanup();
+
+            // Mock fetch to return the expenses for any URL (including global view)
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider paymentMethods={VALID_METHODS}>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Apply all three filters
+            // searchText triggers global view, so apply it first to trigger re-fetch
+            act(() => {
+              result.current.filter.handleSearchChange(searchText);
+            });
+
+            // Wait for re-fetch from global view transition
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Apply type and method filters
+            act(() => {
+              result.current.filter.handleFilterTypeChange(filterType);
+              result.current.filter.handleFilterMethodChange(filterMethod);
+            });
+
+            // Wait for any re-fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Compute expected result using reference implementation with all filters
+            const expected = referenceFilter(expenses, searchText, filterType, filterMethod);
+
+            // Verify filteredExpenses matches reference (AND logic)
+            expect(result.current.expense.filteredExpenses.length).toBe(expected.length);
+            expect(result.current.expense.filteredExpenses.map(e => e.id)).toEqual(
+              expected.map(e => e.id)
+            );
+
+            // Verify each filtered expense satisfies ALL conditions
+            for (const exp of result.current.expense.filteredExpenses) {
+              // searchText: place or notes must contain it (case-insensitive)
+              const searchLower = searchText.toLowerCase();
+              const placeMatch = exp.place && exp.place.toLowerCase().includes(searchLower);
+              const notesMatch = exp.notes && exp.notes.toLowerCase().includes(searchLower);
+              expect(placeMatch || notesMatch).toBe(true);
+
+              // filterType: exact match
+              expect(exp.type).toBe(filterType);
+
+              // filterMethod: exact match
+              expect(exp.method).toBe(filterMethod);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 8f: Filtering is a subset - filteredExpenses is always a subset of expenses
+     * (Req 5.1) - No matter what filters are applied, every filtered expense exists in the original array
+     */
+    it('8f: filteredExpenses is always a subset of the expenses array', { timeout: 60000 }, async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          expenseArrayArb(1, 15),
+          fc.option(fc.array(fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz'), { minLength: 1, maxLength: 8 }).map(a => a.join('')), { nil: '' }),
+          fc.option(fc.constantFrom(...VALID_TYPES), { nil: '' }),
+          fc.option(fc.constantFrom(...VALID_METHODS), { nil: '' }),
+          async (expenses, searchText, filterType, filterMethod) => {
+            cleanup();
+
+            // Mock fetch to return the expenses for any URL
+            globalThis.fetch = vi.fn().mockImplementation(async () => ({
+              ok: true,
+              json: async () => [...expenses],
+              text: async () => JSON.stringify(expenses),
+            }));
+
+            const { result } = renderHook(() => useBothContexts(), {
+              wrapper: ({ children }) => (
+                <FilterProvider paymentMethods={VALID_METHODS}>
+                  <ExpenseProvider>{children}</ExpenseProvider>
+                </FilterProvider>
+              ),
+            });
+
+            // Wait for initial fetch to complete
+            await waitFor(() => {
+              expect(result.current.expense.loading).toBe(false);
+            });
+
+            // Apply whichever filters are non-empty
+            if (searchText) {
+              act(() => {
+                result.current.filter.handleSearchChange(searchText);
+              });
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(false);
+              });
+            }
+
+            if (filterType) {
+              act(() => {
+                result.current.filter.handleFilterTypeChange(filterType);
+              });
+            }
+
+            if (filterMethod) {
+              act(() => {
+                result.current.filter.handleFilterMethodChange(filterMethod);
+              });
+              // filterMethod triggers global view, wait for re-fetch
+              await waitFor(() => {
+                expect(result.current.expense.loading).toBe(false);
+              });
+            }
+
+            // Every filtered expense ID must exist in the full expenses array
+            const allIds = new Set(result.current.expense.expenses.map(e => e.id));
+            for (const exp of result.current.expense.filteredExpenses) {
+              expect(allIds.has(exp.id)).toBe(true);
+            }
+
+            // filteredExpenses length must be <= expenses length
+            expect(result.current.expense.filteredExpenses.length).toBeLessThanOrEqual(
+              result.current.expense.expenses.length
+            );
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+});

--- a/frontend/src/contexts/ExpenseContext.test.jsx
+++ b/frontend/src/contexts/ExpenseContext.test.jsx
@@ -1,0 +1,366 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
+import { FilterProvider, useFilterContext } from './FilterContext';
+import { ExpenseProvider, useExpenseContext } from './ExpenseContext';
+
+// Hook that returns both filter and expense context values
+function useBothContexts() {
+  const filter = useFilterContext();
+  const expense = useExpenseContext();
+  return { filter, expense };
+}
+
+// Helper: wrap with both FilterProvider and ExpenseProvider
+function createWrapper(filterProps = {}) {
+  return function Wrapper({ children }) {
+    return (
+      <FilterProvider {...filterProps}>
+        <ExpenseProvider>{children}</ExpenseProvider>
+      </FilterProvider>
+    );
+  };
+}
+
+// Default mock fetch that returns empty expenses array
+function mockFetchSuccess(data = []) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  });
+}
+
+describe('ExpenseContext Unit Tests', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    // Default: successful empty response
+    globalThis.fetch = mockFetchSuccess([]);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  /**
+   * Requirement 8.2: useExpenseContext throws outside provider
+   */
+  it('useExpenseContext throws when used outside ExpenseProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useExpenseContext())).toThrow(
+      'useExpenseContext must be used within an ExpenseProvider'
+    );
+    spy.mockRestore();
+  });
+
+  /**
+   * ExpenseProvider requires FilterProvider (throws FilterContext error)
+   */
+  it('ExpenseProvider throws when used outside FilterProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      renderHook(() => useExpenseContext(), {
+        wrapper: ({ children }) => <ExpenseProvider>{children}</ExpenseProvider>,
+      })
+    ).toThrow('useFilterContext must be used within a FilterProvider');
+    spy.mockRestore();
+  });
+
+  /**
+   * Requirements 2.1, 2.2, 2.3: Initial state values
+   */
+  it('initializes with empty expenses array', async () => {
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    // Before fetch completes, expenses should be empty array
+    expect(result.current.expenses).toEqual([]);
+  });
+
+  it('initializes loading as false before fetch effect runs', () => {
+    // loading starts as false in useState, then the effect sets it to true
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    // After the initial render + effect, loading may be true or already resolved
+    // The key requirement is that the initial useState default is false
+    expect(typeof result.current.loading).toBe('boolean');
+  });
+
+  it('initializes error as null', async () => {
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  /**
+   * Requirement 2.4: Provides complete interface
+   */
+  it('provides all expected context values and functions', async () => {
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // State values
+    expect(Array.isArray(result.current.expenses)).toBe(true);
+    expect(Array.isArray(result.current.filteredExpenses)).toBe(true);
+    expect(typeof result.current.loading).toBe('boolean');
+    expect(typeof result.current.refreshTrigger).toBe('number');
+    expect(typeof result.current.budgetAlertRefreshTrigger).toBe('number');
+    expect(typeof result.current.currentMonthExpenseCount).toBe('number');
+
+    // CRUD handlers
+    expect(typeof result.current.handleExpenseAdded).toBe('function');
+    expect(typeof result.current.handleExpenseDeleted).toBe('function');
+    expect(typeof result.current.handleExpenseUpdated).toBe('function');
+
+    // Utilities
+    expect(typeof result.current.triggerRefresh).toBe('function');
+    expect(typeof result.current.clearError).toBe('function');
+  });
+
+  /**
+   * Requirement 3.1: Monthly view fetch URL
+   * In monthly view, fetch URL should include year and month params
+   */
+  it('fetches with year and month params in monthly view', async () => {
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const now = new Date();
+    const expectedYear = now.getFullYear();
+    const expectedMonth = now.getMonth() + 1;
+
+    // The initial fetch (for expenses) should use monthly URL
+    const expenseFetchCall = globalThis.fetch.mock.calls.find(
+      (call) => call[0].includes('/api/expenses') && call[0].includes('month=')
+    );
+    expect(expenseFetchCall).toBeDefined();
+    expect(expenseFetchCall[0]).toContain(`year=${expectedYear}`);
+    expect(expenseFetchCall[0]).toContain(`month=${expectedMonth}`);
+  });
+
+  /**
+   * Requirement 3.2: Global view fetch URL (no year filter)
+   * In global view with no year filter, fetch URL should have no query params
+   */
+  it('fetches all expenses in global view with no year filter', async () => {
+    const Wrapper = ({ children }) => (
+      <FilterProvider>
+        <ExpenseProvider>{children}</ExpenseProvider>
+      </FilterProvider>
+    );
+
+    const { result } = renderHook(() => useBothContexts(), { wrapper: Wrapper });
+
+    // Wait for initial fetch to complete
+    await waitFor(() => {
+      expect(result.current.expense.loading).toBe(false);
+    });
+
+    // Clear fetch mock to track new calls
+    globalThis.fetch.mockClear();
+
+    // Trigger global view by setting search text (non-whitespace triggers global)
+    act(() => {
+      result.current.filter.handleSearchChange('test search');
+    });
+
+    await waitFor(() => {
+      expect(result.current.expense.loading).toBe(false);
+    });
+
+    // Find the expense fetch call that does NOT have month= (global view, no year filter)
+    const globalFetchCall = globalThis.fetch.mock.calls.find(
+      (call) => call[0].endsWith('/api/expenses')
+    );
+    expect(globalFetchCall).toBeDefined();
+  });
+
+  /**
+   * Requirement 3.3: Global view with year filter
+   * In global view with a year filter, fetch URL should include only year param
+   */
+  it('fetches with year-only param in global view with year filter', async () => {
+    const Wrapper = ({ children }) => (
+      <FilterProvider>
+        <ExpenseProvider>{children}</ExpenseProvider>
+      </FilterProvider>
+    );
+
+    const { result } = renderHook(() => useBothContexts(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.expense.loading).toBe(false);
+    });
+
+    globalThis.fetch.mockClear();
+
+    // Set year filter (triggers global view)
+    act(() => {
+      result.current.filter.handleFilterYearChange('2023');
+    });
+
+    await waitFor(() => {
+      expect(result.current.expense.loading).toBe(false);
+    });
+
+    // Find the expense fetch call with year=2023 but no month=
+    const yearFilterCall = globalThis.fetch.mock.calls.find(
+      (call) => call[0].includes('year=2023') && !call[0].includes('month=')
+    );
+    expect(yearFilterCall).toBeDefined();
+  });
+
+  /**
+   * Requirement 3.7: Network error produces user-friendly message
+   */
+  it('sets user-friendly error message on network failure', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe(
+      'Unable to connect to the server. Please check your connection and try again.'
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  /**
+   * Requirement 3.8: Server error JSON is parsed
+   */
+  it('parses server error JSON response', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      text: async () => JSON.stringify({ error: 'Database connection failed' }),
+    });
+
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Database connection failed');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('uses default error message when server error is not valid JSON', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      text: async () => 'Internal Server Error',
+    });
+
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Unable to load expenses. Please try again.');
+
+    consoleSpy.mockRestore();
+  });
+
+  /**
+   * Requirements 6.1, 6.2: expensesUpdated event triggers refresh
+   */
+  it('re-fetches expenses when expensesUpdated event is dispatched', async () => {
+    const mockExpenses = [
+      { id: 1, date: '2025-01-15', place: 'Store', amount: 50, type: 'Groceries', method: 'Cash' },
+    ];
+
+    // First call returns empty, subsequent calls return mockExpenses
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return {
+        ok: true,
+        json: async () => (callCount <= 2 ? [] : mockExpenses),
+        text: async () => JSON.stringify(callCount <= 2 ? [] : mockExpenses),
+      };
+    });
+
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const initialRefreshTrigger = result.current.refreshTrigger;
+
+    // Dispatch the expensesUpdated event
+    act(() => {
+      window.dispatchEvent(new Event('expensesUpdated'));
+    });
+
+    // refreshTrigger should increment
+    await waitFor(() => {
+      expect(result.current.refreshTrigger).toBe(initialRefreshTrigger + 1);
+    });
+
+    // Expenses should be re-fetched (new data)
+    await waitFor(() => {
+      expect(result.current.expenses).toEqual(mockExpenses);
+    });
+  });
+
+  it('increments budgetAlertRefreshTrigger when expensesUpdated event fires', async () => {
+    const { result } = renderHook(() => useExpenseContext(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const initialBudgetTrigger = result.current.budgetAlertRefreshTrigger;
+
+    act(() => {
+      window.dispatchEvent(new Event('expensesUpdated'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.budgetAlertRefreshTrigger).toBe(initialBudgetTrigger + 1);
+    });
+  });
+});


### PR DESCRIPTION
Extracts expense data state, fetching logic, CRUD handlers, and client-side filtering from AppContent into a dedicated ExpenseContext. Mirrors the FilterContext pattern from Phase 1.

Changes:
- New ExpenseContext with ExpenseProvider and useExpenseContext hook
- Removed ~8 useState hooks and ~3 useEffect hooks from AppContent
- Unit tests, PBT tests, and integration tests
- No user-facing behavior changes