### PR TITLE
CI: per-worker db isolation and PBT sharding for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   backend-unit-tests:
     name: Backend Unit Tests
     runs-on: ubuntu-latest
-    # Skip CI for Dependabot PRs - tests run when merged to main
     if: github.actor != 'dependabot[bot]'
     defaults:
       run:
@@ -41,11 +40,14 @@ jobs:
         env:
           CI: true
 
-  backend-pbt-tests:
-    name: Backend PBT Tests
+  backend-pbt-shards:
+    name: Backend PBT Shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    # Skip CI for Dependabot PRs - tests run when merged to main
     if: github.actor != 'dependabot[bot]'
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
     defaults:
       run:
         working-directory: backend
@@ -64,13 +66,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run PBT tests
-        run: npm run test:pbt:ci
+      - name: Run PBT tests (shard ${{ matrix.shard }})
+        run: npx cross-env NODE_ENV=test CI=true FAST_CHECK_NUM_RUNS=15 jest --bail --testPathPatterns=pbt --shard=${{ matrix.shard }}
+
+  backend-pbt-tests:
+    name: Backend PBT Tests
+    runs-on: ubuntu-latest
+    if: always() && github.actor != 'dependabot[bot]'
+    needs: backend-pbt-shards
+    steps:
+      - name: Check shard results
+        run: |
+          if [ "${{ needs.backend-pbt-shards.result }}" != "success" ]; then
+            echo "PBT shards failed or were cancelled"
+            exit 1
+          fi
+          echo "All PBT shards passed"
 
   frontend-tests:
     name: Frontend Tests
     runs-on: ubuntu-latest
-    # Skip CI for Dependabot PRs - tests run when merged to main
     if: github.actor != 'dependabot[bot]'
     defaults:
       run:

--- a/.kiro/steering/git-commits.md
+++ b/.kiro/steering/git-commits.md
@@ -15,6 +15,19 @@ This ensures all spec work is isolated and can be cleanly merged with `--no-ff`.
 
 ---
 
+## ⚠️ Branch Protection Active on `main`
+
+Branch protection rules are enabled on the `main` branch in GitHub. This means:
+
+- **Direct pushes to `main` are blocked** — all changes must go through a Pull Request
+- **Required status checks must pass before merging**: `Backend Unit Tests`, `Backend PBT Tests`, `Frontend Tests`
+- **Branches must be up to date** with `main` before merging
+- The `-DirectMerge` flag on `promote-feature.ps1` will **not work** — GitHub will reject the push
+
+All merges to `main` must go through the PR workflow with passing CI.
+
+---
+
 ## Commit Control
 
 The agent can auto-commit in specific scenarios, but otherwise defers to the user.
@@ -143,26 +156,17 @@ When making quick changes directly on main (bug fixes, version bumps, etc.), use
 |----------|---------------|
 | Promoting a feature branch | `promote-feature.ps1 -FeatureName <name>` |
 | Quick fix made on main | `create-pr-from-main.ps1 -Title "<description>"` |
-| Emergency hotfix (skip CI) | `promote-feature.ps1 -FeatureName <name> -DirectMerge` |
-| CI already verified on branch | `promote-feature.ps1 -FeatureName <name> -DirectMerge` |
 
-### Direct Merge (Bypass PR)
+### Direct Merge (Blocked by Branch Protection)
 
-Use the `-DirectMerge` flag only when:
-- Making an emergency hotfix that needs immediate deployment
-- CI was already run and verified on the feature branch
-- The change is documentation-only and doesn't affect code
-
-```powershell
-.\scripts\promote-feature.ps1 -FeatureName your-feature -DirectMerge
-```
+The `-DirectMerge` flag on `promote-feature.ps1` is **no longer usable** for merging to `main`. Branch protection rules reject direct pushes. All merges must go through a PR with passing CI status checks.
 
 ### Agent Guidance
 
 When assisting with feature promotion:
-1. **Default to PR workflow** - Use `promote-feature.ps1` without `-DirectMerge`
-2. **For quick fixes on main** - Use `create-pr-from-main.ps1`
-3. **Only suggest `-DirectMerge`** when the user explicitly needs to bypass CI
+1. **Always use PR workflow** — Use `promote-feature.ps1` without `-DirectMerge`
+2. **For quick fixes on main** — Use `create-pr-from-main.ps1`
+3. **Never suggest `-DirectMerge`** — Branch protection will block it
 
 When assisting with changes directly on main:
 1. After making changes, suggest using `create-pr-from-main.ps1`

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -35,7 +35,7 @@ npm test -- --testNamePattern="pattern"  # for test names, not file paths
 ### Common Backend Test Commands
 
 ```bash
-# Run all backend tests
+# Run all backend tests (sequential - for local dev)
 npm test
 
 # Run fast tests (reduced PBT iterations)
@@ -53,6 +53,9 @@ npm test -- --testPathPatterns="serviceName"
 # Run tests with verbose output
 npm test -- --testPathPatterns="serviceName" --verbose
 ```
+
+Note: Local test commands use `--runInBand` (sequential) for simplicity.
+CI commands (`test:unit:ci`, `test:pbt:ci`) run in parallel with per-worker database isolation.
 
 ### Working Directory
 

--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -84,9 +84,9 @@ afterAll(async () => {
     return;
   }
   
-  // Don't close the database here - it's shared across test files
-  // and Jest runs files in parallel. The database will be cleaned up
-  // when the process exits.
+  // Close the per-worker database connection and clean up the file
+  const { closeTestDatabase } = require('./database/db');
+  closeTestDatabase();
   testDbInitialized = false;
 });
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,10 +12,10 @@
     "test": "cross-env NODE_ENV=test jest --runInBand",
     "test:fast": "cross-env NODE_ENV=test FAST_CHECK_NUM_RUNS=10 jest --runInBand",
     "test:unit": "cross-env NODE_ENV=test jest --runInBand --testPathIgnorePatterns=pbt",
-    "test:unit:ci": "cross-env NODE_ENV=test CI=true jest --runInBand --bail --testPathIgnorePatterns=pbt",
+    "test:unit:ci": "cross-env NODE_ENV=test CI=true jest --bail --testPathIgnorePatterns=pbt",
     "test:pbt": "cross-env NODE_ENV=test jest --runInBand --testPathPatterns=pbt",
-    "test:pbt:ci": "cross-env NODE_ENV=test CI=true FAST_CHECK_NUM_RUNS=15 jest --runInBand --bail --testPathPatterns=pbt",
-    "test:ci": "cross-env NODE_ENV=test CI=true FAST_CHECK_NUM_RUNS=15 jest --runInBand --bail"
+    "test:pbt:ci": "cross-env NODE_ENV=test CI=true FAST_CHECK_NUM_RUNS=15 jest --bail --testPathPatterns=pbt",
+    "test:ci": "cross-env NODE_ENV=test CI=true FAST_CHECK_NUM_RUNS=15 jest --bail"
   },
   "jest": {
     "testTimeout": 30000,


### PR DESCRIPTION
Optimizes backend CI test execution time by enabling parallel test execution.

Changes:
- Per-worker SQLite database isolation (test-expenses-worker-{id}.db) so Jest workers don't share a single DB
- Removed --runInBand from CI scripts (local scripts still use it)
- PBT tests sharded across 3 parallel runners with a summary job for branch protection
- Worker cleanup in jest.setup.js and global cleanup in jest.globalSetup.js
- Updated docs: testing.md, GITHUB_ACTIONS_CICD.md, FEATURE_BRANCH_WORKFLOW.md, git-commits.md