### PR TITLE
Hotfix: billing cycle PDF upload on update + deploy script CI polling fix

### DIFF
--- a/backend/routes/billingCycleRoutes.js
+++ b/backend/routes/billingCycleRoutes.js
@@ -36,8 +36,14 @@ router.post(
 // GET /api/payment-methods/:id/billing-cycles/:cycleId/pdf - Get billing cycle PDF
 router.get('/:id/billing-cycles/:cycleId/pdf', billingCycleController.getBillingCyclePdf);
 
-// PUT /api/payment-methods/:id/billing-cycles/:cycleId - Update a billing cycle record
-router.put('/:id/billing-cycles/:cycleId', billingCycleController.updateBillingCycle);
+// PUT /api/payment-methods/:id/billing-cycles/:cycleId - Update a billing cycle record (with optional PDF)
+router.put(
+  '/:id/billing-cycles/:cycleId',
+  validateUploadRequest,
+  upload.single('statement'),
+  handleMulterError,
+  billingCycleController.updateBillingCycle
+);
 
 // DELETE /api/payment-methods/:id/billing-cycles/:cycleId - Delete a billing cycle record
 router.delete('/:id/billing-cycles/:cycleId', billingCycleController.deleteBillingCycle);

--- a/backend/services/billingCycleHistoryService.js
+++ b/backend/services/billingCycleHistoryService.js
@@ -440,12 +440,19 @@ class BillingCycleHistoryService {
     
     // Update the record (repository preserves calculated_statement_balance)
     // Mark as user-entered since user is explicitly updating
-    const updated = await billingCycleRepository.update(cycleId, {
+    const updatePayload = {
       actual_statement_balance: data.actual_statement_balance,
       minimum_payment: data.minimum_payment,
       notes: data.notes,
       is_user_entered: 1  // Mark as user-entered when user updates
-    });
+    };
+    
+    // Pass statement_pdf_path if provided (from PDF upload)
+    if (data.statement_pdf_path !== undefined) {
+      updatePayload.statement_pdf_path = data.statement_pdf_path;
+    }
+    
+    const updated = await billingCycleRepository.update(cycleId, updatePayload);
     
     if (!updated) {
       const error = new Error('Failed to update billing cycle record');

--- a/frontend/src/services/creditCardApi.js
+++ b/frontend/src/services/creditCardApi.js
@@ -491,15 +491,40 @@ export const getBillingCycleHistory = async (paymentMethodId, options = {}) => {
  */
 export const updateBillingCycle = async (paymentMethodId, cycleId, data) => {
   try {
-    const response = await fetchWithRetry(
-      API_ENDPOINTS.PAYMENT_METHOD_BILLING_CYCLE_UPDATE(paymentMethodId, cycleId),
-      {
+    let fetchOptions;
+    
+    // If there's a PDF file, use FormData (same pattern as createBillingCycle)
+    if (data.statement) {
+      const formData = new FormData();
+      if (data.actual_statement_balance !== undefined && data.actual_statement_balance !== null) {
+        formData.append('actual_statement_balance', data.actual_statement_balance.toString());
+      }
+      if (data.minimum_payment !== undefined && data.minimum_payment !== null) {
+        formData.append('minimum_payment', data.minimum_payment.toString());
+      }
+      if (data.notes !== undefined && data.notes !== null) {
+        formData.append('notes', data.notes);
+      }
+      formData.append('statement', data.statement);
+      
+      fetchOptions = {
+        method: 'PUT',
+        body: formData
+      };
+    } else {
+      // No file, use JSON
+      fetchOptions = {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(data)
-      }
+      };
+    }
+    
+    const response = await fetchWithRetry(
+      API_ENDPOINTS.PAYMENT_METHOD_BILLING_CYCLE_UPDATE(paymentMethodId, cycleId),
+      fetchOptions
     );
     
     if (!response.ok) {

--- a/scripts/deploy-to-production.ps1
+++ b/scripts/deploy-to-production.ps1
@@ -307,7 +307,7 @@ while ($elapsed -lt $CITimeout) {
                 $anyFailed = $true
                 break
             }
-            if ($check.state -ne "SUCCESS") {
+            if ($check.state -ne "SUCCESS" -and $check.state -ne "SKIPPED") {
                 $allComplete = $false
             }
         }


### PR DESCRIPTION
## Fixes

### 1. Billing cycle PDF upload on update
Added PDF upload support to the billing cycle update endpoint. Previously only the create path supported file uploads. With auto-generated cycles, users now edit existing cycles and need to attach statements.

**Changes across 4 layers:**
- Route: Added multer middleware to PUT endpoint
- Controller: Handle req.file, save PDF, cleanup old PDF on replace
- Service: Pass statement_pdf_path through to repository
- Frontend API: Switch to FormData when file is present

### 2. Deploy script CI polling fix
Fixed PHASE 6 polling loop that got stuck when CI checks had SKIPPED state. Now accepts both SUCCESS and SKIPPED.

### Tests
- Added 4 new unit tests for PDF upload on update (save, replace/cleanup, form-data string parsing)
- All 38 controller tests pass