### PR TITLE
fix: misc bug fixes - budget alerts, backup naming, monthly filter, activity log, investment edit

### DIFF
--- a/backend/controllers/backupController.js
+++ b/backend/controllers/backupController.js
@@ -96,19 +96,10 @@ async function downloadBackup(req, res) {
       fs.mkdirSync(tempDir, { recursive: true });
     }
 
-    // Generate filename with timestamp
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').split('T')[0];
-    const filename = `expense-tracker-backup-${timestamp}.tar.gz`;
-    const tempFilePath = path.join(tempDir, filename);
-
-    // Create the backup archive
+    // Create the backup archive (includes version and SHA in filename)
     const result = await backupService.performBackup(tempDir);
-    
-    // The backup service creates a file with its own timestamp, rename it
-    const createdFile = result.path;
-    if (createdFile !== tempFilePath && fs.existsSync(createdFile)) {
-      fs.renameSync(createdFile, tempFilePath);
-    }
+    const tempFilePath = result.path;
+    const filename = result.filename;
 
     // Set headers for file download
     res.setHeader('Content-Type', 'application/gzip');

--- a/backend/services/expenseService.js
+++ b/backend/services/expenseService.js
@@ -335,12 +335,13 @@ class ExpenseService {
       'expense_added',
       'expense',
       createdExpense.id,
-      `Added expense: ${expense.place || 'Unknown'} - $${expense.amount.toFixed(2)}`,
+      `Added expense: ${expense.place || 'Unknown'} - ${expense.amount.toFixed(2)} (${expense.date}, ${method})`,
       {
         amount: expense.amount,
         category: expense.type,
         date: expense.date,
-        place: expense.place
+        place: expense.place,
+        method: method
       }
     );
 
@@ -560,12 +561,13 @@ class ExpenseService {
       'expense_updated',
       'expense',
       id,
-      `Updated expense: ${expense.place || 'Unknown'} - $${expense.amount.toFixed(2)}${changeSummary}`,
+      `Updated expense: ${expense.place || 'Unknown'} - ${expense.amount.toFixed(2)} on ${expense.date}${changeSummary}`,
       {
         amount: expense.amount,
         category: expense.type,
         date: expense.date,
         place: expense.place,
+        method: expense.method,
         changes: changes
       }
     );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -241,14 +241,11 @@ function AppContent({ onPaymentMethodsUpdate }) {
   }, [selectedYear, selectedMonth, budgetAlertRefreshTrigger]);
 
   // Listen for navigateToExpenseList event (e.g., from BudgetReminderBanner)
+  // Only closes overlays — the category filter is applied as a local (monthly) filter
+  // by ExpenseList directly, so the user stays in monthly view for budget context.
   useEffect(() => {
-    const handleNavigateToExpenseList = (event) => {
+    const handleNavigateToExpenseList = () => {
       closeAllOverlays();
-      
-      // Use context handler for filter state update
-      if (event.detail?.categoryFilter) {
-        handleFilterTypeChange(event.detail.categoryFilter);
-      }
     };
 
     window.addEventListener('navigateToExpenseList', handleNavigateToExpenseList);
@@ -256,7 +253,7 @@ function AppContent({ onPaymentMethodsUpdate }) {
     return () => {
       window.removeEventListener('navigateToExpenseList', handleNavigateToExpenseList);
     };
-  }, [handleFilterTypeChange, closeAllOverlays]);
+  }, [closeAllOverlays]);
 
   // Listen for filterByInsuranceStatus event
   useEffect(() => {

--- a/frontend/src/components/ExpenseList.jsx
+++ b/frontend/src/components/ExpenseList.jsx
@@ -290,6 +290,21 @@ const ExpenseList = memo(({
     }
   }, [initialInsuranceFilter]);
 
+  // Listen for navigateToExpenseList event to set local category filter (monthly scope)
+  // Budget alerts dispatch this so the user sees what's driving their monthly budget
+  useEffect(() => {
+    const handleNavigateToExpenseList = (event) => {
+      if (event.detail?.categoryFilter) {
+        setLocalFilterType(event.detail.categoryFilter);
+      }
+    };
+
+    window.addEventListener('navigateToExpenseList', handleNavigateToExpenseList);
+    return () => {
+      window.removeEventListener('navigateToExpenseList', handleNavigateToExpenseList);
+    };
+  }, []);
+
   // Notify parent only when clearing insurance filter (to exit global view if banner triggered it)
   const handleInsuranceFilterChange = useCallback((value) => {
     setLocalFilterInsurance(value);

--- a/frontend/src/components/InvestmentsModal.jsx
+++ b/frontend/src/components/InvestmentsModal.jsx
@@ -166,7 +166,8 @@ const InvestmentsModal = ({ isOpen, onClose, onUpdate, highlightIds = [] }) => {
     try {
       await updateInvestment(editingInvestmentId, {
         name: formData.name.trim(),
-        type: formData.type
+        type: formData.type,
+        initial_value: parseFloat(formData.initial_value)
       });
       
       // Refresh investments list

--- a/frontend/src/components/SummaryPanel.jsx
+++ b/frontend/src/components/SummaryPanel.jsx
@@ -641,6 +641,18 @@ const SummaryPanel = ({ selectedYear, selectedMonth, refreshTrigger }) => {
 
   return (
     <div className="summary-panel">
+      {/* BudgetAlertManager must render outside NotificationsSection so it always mounts,
+          fetches data, and reports visibility. Otherwise when budget alerts are the only
+          notification, NotificationsSection returns null (count=0) and the manager never
+          mounts — a chicken-and-egg problem. */}
+      <BudgetAlertManager
+        year={selectedYear}
+        month={selectedMonth}
+        refreshTrigger={refreshTrigger}
+        onClick={handleBudgetAlertReminderClick}
+        onVisibilityChange={setBudgetAlertsVisible}
+      />
+
       {/* Notifications Section - Contains all reminder banners */}
       {/* _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_ */}
       <NotificationsSection notificationCount={notificationCount}>
@@ -717,17 +729,6 @@ const SummaryPanel = ({ selectedYear, selectedMonth, refreshTrigger }) => {
             onClick={handleInsuranceClaimReminderClick}
           />
         )}
-
-        {/* Budget Alert Reminders - Requirements: 6.1, 6.2, 6.4 */}
-        {/* BudgetAlertManager handles its own data fetching, caching, and dismissal */}
-        {/* It notifies parent of actual visibility via onVisibilityChange callback */}
-        <BudgetAlertManager
-          year={selectedYear}
-          month={selectedMonth}
-          refreshTrigger={refreshTrigger}
-          onClick={handleBudgetAlertReminderClick}
-          onVisibilityChange={setBudgetAlertsVisible}
-        />
 
         {/* Investment Data Reminders */}
         {reminderStatus.hasActiveInvestments && 


### PR DESCRIPTION
## Bug Fixes

- **Budget alerts not showing**: Fixed chicken-and-egg mount issue where BudgetAlertManager was rendered inside NotificationsSection, which returns null when count=0. Moved it outside so it always mounts and reports visibility.
- **Backup download naming**: Fixed downloadBackup controller generating its own simple filename instead of using the version+SHA format from backupService.
- **Budget alert monthly filter**: Changed budget alert category click to use local monthly filter instead of global view, so users see what's driving their monthly budget.
- **Activity log detail**: Added payment method to expense activity log metadata for better audit trail.
- **Investment edit**: Fixed investment edit not sending initial_value to the backend.