### PR TITLE
fix: render budget alerts inside notification box

### DIFF
--- a/frontend/src/components/BudgetAlertFlow.integration.test.jsx
+++ b/frontend/src/components/BudgetAlertFlow.integration.test.jsx
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import BudgetAlertManager from './BudgetAlertManager';
 import * as budgetApi from '../services/budgetApi';
+
+// Wrapper that captures onRenderContent and renders it, mimicking SummaryPanel behavior
+const ManagerWithRender = (props) => {
+  const [content, setContent] = useState(null);
+  return (
+    <>
+      <BudgetAlertManager {...props} onRenderContent={setContent} />
+      {content}
+    </>
+  );
+};
 
 // Mock the budget API
 vi.mock('../services/budgetApi');
@@ -56,7 +68,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     budgetApi.getBudgets.mockImplementation(async () => ({ budgets: getBudgetData() }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -73,7 +85,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     currentSpent = 400; // 80% of $500
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -95,7 +107,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     currentSpent = 450; // 90% of $500
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={2}
@@ -117,7 +129,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     currentSpent = 550; // 110% of $500
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={3}
@@ -152,7 +164,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
 
     // Step 6: Test session persistence - alert should remain dismissed during same session
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={4}
@@ -171,7 +183,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     
     // Change month to trigger clearDismissalState effect, then change back
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={5}
@@ -184,7 +196,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
 
     // Change back to original month with cleared dismissal state
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={6}
@@ -223,7 +235,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     }] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={0}
@@ -240,7 +252,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     currentSpent = 1050;
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={1}
@@ -259,7 +271,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     currentSpent = 850;
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={2}
@@ -278,7 +290,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     currentSpent = 700;
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={3}
@@ -307,7 +319,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     }] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -335,7 +347,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
     
     // First change month to clear dismissal state
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={1}
@@ -348,7 +360,7 @@ describe('Budget Alert Flow - Complete Integration Test', () => {
 
     // Change back to original month - dismissal state is now cleared
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={2}

--- a/frontend/src/components/BudgetAlertInteractions.integration.test.jsx
+++ b/frontend/src/components/BudgetAlertInteractions.integration.test.jsx
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import BudgetAlertManager from './BudgetAlertManager';
 import * as budgetApi from '../services/budgetApi';
+
+// Wrapper that captures onRenderContent and renders it, mimicking SummaryPanel behavior
+const ManagerWithRender = (props) => {
+  const [content, setContent] = useState(null);
+  return (
+    <>
+      <BudgetAlertManager {...props} onRenderContent={setContent} />
+      {content}
+    </>
+  );
+};
 
 // Mock the budget API
 vi.mock('../services/budgetApi');
@@ -33,7 +45,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     ] });
 
     render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -65,7 +77,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     ] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -83,7 +95,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     budgetSpent = 300; // Now 60% spent (no alert)
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -108,7 +120,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     ] });
 
     render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -144,7 +156,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     ] });
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -168,7 +180,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
 
     // Simulate different refreshTrigger (like after expense operation)
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -183,7 +195,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
 
     // Simulate month change (clears dismissal state)
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={1}
@@ -214,7 +226,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     ] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -232,7 +244,7 @@ describe('Budget Alert Interactions - Integration Tests', () => {
     budgetLimit = 600; // Now 75% spent (no alert)
 
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}

--- a/frontend/src/components/BudgetAlertManager.jsx
+++ b/frontend/src/components/BudgetAlertManager.jsx
@@ -22,7 +22,8 @@ const BudgetAlertManager = ({
   month, 
   refreshTrigger, 
   onClick,  // Single onClick handler for category navigation - Requirements: 6.4
-  onVisibilityChange  // Callback to notify parent of actual visibility state
+  onVisibilityChange,  // Callback to notify parent of actual visibility state
+  onRenderContent  // Callback to pass rendered banner JSX to parent for placement inside NotificationsSection
 }) => {
   const [alerts, setAlerts] = useState([]);
   const [dismissed, setDismissed] = useState(false);
@@ -296,18 +297,25 @@ const BudgetAlertManager = ({
     }
   }, [isVisible, onVisibilityChange]);
 
-  // Don't render anything if not visible
-  if (!isVisible) {
-    return null;
-  }
+  // Pass rendered content to parent so it can be placed inside NotificationsSection
+  useEffect(() => {
+    if (onRenderContent) {
+      if (isVisible) {
+        onRenderContent(
+          <BudgetReminderBanner
+            alerts={alerts}
+            onDismiss={handleDismiss}
+            onClick={handleClick}
+          />
+        );
+      } else {
+        onRenderContent(null);
+      }
+    }
+  }, [isVisible, alerts, handleDismiss, handleClick, onRenderContent]);
 
-  return (
-    <BudgetReminderBanner
-      alerts={alerts}
-      onDismiss={handleDismiss}
-      onClick={handleClick}
-    />
-  );
+  // Rendering is handled by the parent via onRenderContent callback
+  return null;
 };
 
 export default BudgetAlertManager;

--- a/frontend/src/components/BudgetAlertMultiple.integration.test.jsx
+++ b/frontend/src/components/BudgetAlertMultiple.integration.test.jsx
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import BudgetAlertManager from './BudgetAlertManager';
 import * as budgetApi from '../services/budgetApi';
+
+// Wrapper that captures onRenderContent and renders it, mimicking SummaryPanel behavior
+const ManagerWithRender = (props) => {
+  const [content, setContent] = useState(null);
+  return (
+    <>
+      <BudgetAlertManager {...props} onRenderContent={setContent} />
+      {content}
+    </>
+  );
+};
 
 // Mock the budget API
 vi.mock('../services/budgetApi');
@@ -54,7 +66,7 @@ describe('Budget Alert Multiple Alerts - Integration Test', () => {
     budgetApi.getBudgets.mockResolvedValue({ budgets: budgetData });
 
     render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}

--- a/frontend/src/components/BudgetAlertRealTime.integration.test.jsx
+++ b/frontend/src/components/BudgetAlertRealTime.integration.test.jsx
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import BudgetAlertManager from './BudgetAlertManager';
 import * as budgetApi from '../services/budgetApi';
+
+// Wrapper that captures onRenderContent and renders it, mimicking SummaryPanel behavior
+const ManagerWithRender = (props) => {
+  const [content, setContent] = useState(null);
+  return (
+    <>
+      <BudgetAlertManager {...props} onRenderContent={setContent} />
+      {content}
+    </>
+  );
+};
 
 // Mock the budget API
 vi.mock('../services/budgetApi');
@@ -55,7 +67,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     budgetApi.getBudgets.mockImplementation(async () => ({ budgets: getBudgetData() }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -80,7 +92,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 350; // 70% of $500 (below 80% threshold)
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -98,7 +110,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 425; // 85% of $500 (warning level)
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={2}
@@ -121,7 +133,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 475; // 95% of $500 (danger level)
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={3}
@@ -143,7 +155,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 550; // 110% of $500 (critical level)
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={4}
@@ -175,7 +187,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     }] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -191,7 +203,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     // Rapid changes - simulate multiple expense operations in quick succession
     currentSpent = 850; // 85% (warning)
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -201,7 +213,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
 
     currentSpent = 920; // 92% (danger)
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={2}
@@ -211,7 +223,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
 
     currentSpent = 1100; // 110% (critical)
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={3}
@@ -240,7 +252,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     }] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -270,7 +282,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 246;
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -289,7 +301,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     
     // First change month to clear dismissal state
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={12}
         refreshTrigger={2}
@@ -302,7 +314,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
 
     // Change back to original month with cleared dismissal state
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={3}
@@ -338,7 +350,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     }] }));
 
     const { rerender } = render(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={0}
@@ -355,7 +367,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 80.01;
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={1}
@@ -372,7 +384,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 79.99;
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={2}
@@ -389,7 +401,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 80.00; // Exactly 80%
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={3}
@@ -405,7 +417,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 90.00; // Exactly 90%
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={4}
@@ -423,7 +435,7 @@ describe('Budget Alert Real-time Updates - Integration Test', () => {
     currentSpent = 100.00; // Exactly 100%
     
     rerender(
-      <BudgetAlertManager
+      <ManagerWithRender
         year={2025}
         month={11}
         refreshTrigger={5}

--- a/frontend/src/components/SummaryPanel.jsx
+++ b/frontend/src/components/SummaryPanel.jsx
@@ -97,6 +97,7 @@ const SummaryPanel = ({ selectedYear, selectedMonth, refreshTrigger }) => {
   // Budget alerts are now managed by BudgetAlertManager component
   // _Requirements: 6.1, 6.2, 6.4_
   const [budgetAlertsVisible, setBudgetAlertsVisible] = useState(false);
+  const [budgetAlertRenderContent, setBudgetAlertRenderContent] = useState(null);
   
   // Payment Methods Modal state
   const [showPaymentMethodsModal, setShowPaymentMethodsModal] = useState(false);
@@ -641,21 +642,24 @@ const SummaryPanel = ({ selectedYear, selectedMonth, refreshTrigger }) => {
 
   return (
     <div className="summary-panel">
-      {/* BudgetAlertManager must render outside NotificationsSection so it always mounts,
-          fetches data, and reports visibility. Otherwise when budget alerts are the only
-          notification, NotificationsSection returns null (count=0) and the manager never
-          mounts — a chicken-and-egg problem. */}
+      {/* BudgetAlertManager renders outside NotificationsSection so it always mounts,
+          fetches data, and reports visibility (avoids chicken-and-egg problem).
+          It uses renderContent callback to pass its banner JSX into NotificationsSection. */}
       <BudgetAlertManager
         year={selectedYear}
         month={selectedMonth}
         refreshTrigger={refreshTrigger}
         onClick={handleBudgetAlertReminderClick}
         onVisibilityChange={setBudgetAlertsVisible}
+        onRenderContent={setBudgetAlertRenderContent}
       />
 
       {/* Notifications Section - Contains all reminder banners */}
       {/* _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_ */}
       <NotificationsSection notificationCount={notificationCount}>
+        {/* Budget Alerts - rendered via BudgetAlertManager's onRenderContent callback */}
+        {budgetAlertRenderContent}
+
         {/* Credit Card Overdue Reminders - Most urgent, show first */}
         {reminderStatus.creditCardReminders?.overdueCount > 0 && 
          !dismissedReminders.creditCardOverdue && (


### PR DESCRIPTION
Budget alerts were rendering outside the notification box after the chicken-and-egg fix. This adds an onRenderContent callback pattern so BudgetAlertManager still mounts independently (always fetches data) but passes its render content back to SummaryPanel, which renders it inside NotificationsSection. All 56 budget alert tests pass.