### PR TITLE
fix: SSE sync not refreshing SummaryPanel and budget alerts on remote sessions

### DIFF
--- a/frontend/src/contexts/ExpenseContext.jsx
+++ b/frontend/src/contexts/ExpenseContext.jsx
@@ -151,6 +151,8 @@ export function ExpenseProvider({ children }) {
 
   /** Called by useDataSync on remote SSE expense events — re-fetches from server */
   const refreshExpenses = useCallback(() => {
+    setRefreshTrigger(prev => prev + 1);
+    setBudgetAlertRefreshTrigger(prev => prev + 1);
     window.dispatchEvent(new CustomEvent('expensesUpdated'));
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes SSE sync not triggering SummaryPanel and budget alert refreshes on remote sessions.

### Root Cause
efreshExpenses in ExpenseContext dispatched the xpensesUpdated window event but did not increment efreshTrigger or udgetAlertRefreshTrigger, so SummaryPanel and budget alerts never refreshed on remote SSE events.

### Fix
Added setRefreshTrigger(prev => prev + 1) and setBudgetAlertRefreshTrigger(prev => prev + 1) to efreshExpenses in ExpenseContext.jsx.

## Checklist
- [x] Verified working on test container (port 2627)
- [ ] CI passes
- [ ] Ready to merge