### PR TITLE
fix: useTabState PBT localStorage error test - clear storage between runs

### DIFF
--- a/frontend/src/hooks/useTabState.pbt.test.js
+++ b/frontend/src/hooks/useTabState.pbt.test.js
@@ -110,8 +110,10 @@ describe('useTabState - Property-Based Tests', () => {
         fc.string({ minLength: 1, maxLength: 20 }), // storageKey
         fc.string({ minLength: 1, maxLength: 20 }), // defaultTab
         (storageKey, defaultTab) => {
+          localStorage.clear();
+
           // Mock localStorage.getItem to throw error
-          const originalGetItem = localStorage.getItem;
+          const originalGetItem = localStorage.getItem.bind(localStorage);
           localStorage.getItem = vi.fn(() => {
             throw new Error('localStorage error');
           });
@@ -120,8 +122,9 @@ describe('useTabState - Property-Based Tests', () => {
           const { result } = renderHook(() => useTabState(storageKey, defaultTab));
           expect(result.current[0]).toBe(defaultTab);
 
-          // Restore original
+          // Restore original and clear any values written during this run
           localStorage.getItem = originalGetItem;
+          localStorage.clear();
         }
       ),
       { numRuns: 50 }


### PR DESCRIPTION
## Summary

The Property 7 localStorage error handling test was not clearing localStorage before each property run. After mocking getItem to throw, the useEffect in useTabState still wrote to localStorage via setItem. On the next run, the restored getItem would find that stale value, causing the hook to return the previous run's defaultTab instead of the current one. Fix: add localStorage.clear() before mocking and after restoring getItem within the property body.

## Checklist

- [ ] CI passes
- [ ] Ready to merge