### PR TITLE
refactor: split paymentMethodService into sub-services

### DIFF
--- a/backend/services/paymentMethodBalanceService.js
+++ b/backend/services/paymentMethodBalanceService.js
@@ -1,0 +1,349 @@
+const paymentMethodRepository = require('../repositories/paymentMethodRepository');
+const logger = require('../config/logger');
+const { getTodayString } = require('../utils/dateUtils');
+
+/**
+ * Service for credit card balance and utilization calculations
+ * Extracted from paymentMethodService.js for separation of concerns
+ */
+class PaymentMethodBalanceService {
+  /**
+   * Calculate projected balance for a credit card
+   * Sum of ALL expenses minus ALL payments
+   * @param {number} paymentMethodId - Credit card ID
+   * @returns {Promise<number>} Projected balance (minimum 0)
+   */
+  async calculateProjectedBalance(paymentMethodId) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Balance calculations only available for credit cards');
+    }
+
+    const { getDatabase } = require('../database/db');
+    const db = await getDatabase();
+
+    // Sum ALL expenses regardless of date
+    // Use original_cost when set (for medical expenses with insurance) to reflect full credit card charge
+    const expenseTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ?',
+        [paymentMethodId],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    // Sum ALL payments regardless of date
+    const paymentTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ?',
+        [paymentMethodId],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
+
+    logger.debug('Calculated projected balance:', {
+      paymentMethodId,
+      expenseTotal,
+      paymentTotal,
+      balance
+    });
+
+    return balance;
+  }
+
+  /**
+   * Calculate current (posted) balance for a credit card
+   * Sum of expenses with effective_date <= today minus payments <= today
+   * @param {number} paymentMethodId - Credit card ID
+   * @returns {Promise<number>} Current balance (minimum 0)
+   */
+  async calculateCurrentBalance(paymentMethodId) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Balance calculations only available for credit cards');
+    }
+
+    const { getDatabase } = require('../database/db');
+    const db = await getDatabase();
+
+    const todayStr = getTodayString();
+
+    // Sum expenses where effective_date <= today
+    const expenseTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
+        [paymentMethodId, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    // Sum payments where payment_date <= today
+    const paymentTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ? AND payment_date <= ?',
+        [paymentMethodId, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
+
+    logger.debug('Calculated current balance:', {
+      paymentMethodId,
+      todayStr,
+      expenseTotal,
+      paymentTotal,
+      balance
+    });
+
+    return balance;
+  }
+
+  /**
+   * Calculate statement balance for a credit card
+   * Delegates to statementBalanceService when billing_cycle_day is configured.
+   * Falls back to legacy billing_cycle_start/end calculation for backward compatibility.
+   * @param {number} paymentMethodId - Credit card ID
+   * @returns {Promise<number|null>} Statement balance or null if no billing cycle
+   */
+  async calculateStatementBalance(paymentMethodId) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Balance calculations only available for credit cards');
+    }
+
+    // MODERN APPROACH: Use statementBalanceService when billing_cycle_day is configured
+    if (paymentMethod.billing_cycle_day) {
+      const statementBalanceService = require('./statementBalanceService');
+      const result = await statementBalanceService.calculateStatementBalance(paymentMethodId);
+      return result ? result.statementBalance : null;
+    }
+
+    // LEGACY FALLBACK: Use billing_cycle_start/end for cards without billing_cycle_day
+    if (!paymentMethod.billing_cycle_start || !paymentMethod.billing_cycle_end) {
+      return null;
+    }
+
+    // Lazy require to avoid circular dependency
+    const paymentMethodBillingCycleService = require('./paymentMethodBillingCycleService');
+    const billingCycle = paymentMethodBillingCycleService.calculateCurrentBillingCycle(
+      paymentMethod.billing_cycle_start,
+      paymentMethod.billing_cycle_end
+    );
+
+    if (!billingCycle) {
+      return null;
+    }
+
+    const { getDatabase } = require('../database/db');
+    const db = await getDatabase();
+
+    const expenseTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) < ?',
+        [paymentMethodId, billingCycle.startDate],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const paymentTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ? AND payment_date < ?',
+        [paymentMethodId, billingCycle.startDate],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
+
+    logger.debug('Calculated statement balance (legacy):', {
+      paymentMethodId,
+      cycleStartDate: billingCycle.startDate,
+      expenseTotal,
+      paymentTotal,
+      balance
+    });
+
+    return balance;
+  }
+
+  /**
+   * Get all three balance types for a credit card
+   * @param {number} paymentMethodId - Credit card ID
+   * @returns {Promise<Object>} Object with all balance types
+   */
+  async getAllBalanceTypes(paymentMethodId) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Balance calculations only available for credit cards');
+    }
+
+    const [statementBalance, currentBalance, projectedBalance] = await Promise.all([
+      this.calculateStatementBalance(paymentMethodId),
+      this.calculateCurrentBalance(paymentMethodId),
+      this.calculateProjectedBalance(paymentMethodId)
+    ]);
+
+    const hasPendingExpenses = projectedBalance !== currentBalance;
+
+    // Lazy require to avoid circular dependency
+    const paymentMethodBillingCycleService = require('./paymentMethodBillingCycleService');
+    let billingCycle = null;
+    if (paymentMethod.billing_cycle_start && paymentMethod.billing_cycle_end) {
+      billingCycle = paymentMethodBillingCycleService.calculateCurrentBillingCycle(
+        paymentMethod.billing_cycle_start,
+        paymentMethod.billing_cycle_end
+      );
+    }
+
+    logger.debug('Retrieved all balance types:', {
+      paymentMethodId,
+      statementBalance,
+      currentBalance,
+      projectedBalance,
+      hasPendingExpenses
+    });
+
+    return {
+      statement_balance: statementBalance,
+      current_balance: currentBalance,
+      projected_balance: projectedBalance,
+      has_pending_expenses: hasPendingExpenses,
+      billing_cycle: billingCycle ? {
+        start_date: billingCycle.startDate,
+        end_date: billingCycle.endDate
+      } : null
+    };
+  }
+
+  /**
+   * Calculate credit utilization percentage
+   * @param {number} balance - Current balance
+   * @param {number} creditLimit - Credit limit
+   * @returns {number|null} Utilization percentage (0-100+) or null if no limit
+   */
+  calculateUtilizationPercentage(balance, creditLimit) {
+    if (!creditLimit || creditLimit <= 0) {
+      return null;
+    }
+    
+    const utilization = (balance / creditLimit) * 100;
+    return Math.round(utilization * 100) / 100;
+  }
+
+  /**
+   * Get utilization status based on percentage
+   * @param {number} utilizationPercentage - Utilization percentage
+   * @returns {string} Status: 'good', 'warning', or 'danger'
+   */
+  getUtilizationStatus(utilizationPercentage) {
+    if (utilizationPercentage === null || utilizationPercentage === undefined) {
+      return 'unknown';
+    }
+    
+    if (utilizationPercentage >= 70) {
+      return 'danger';
+    } else if (utilizationPercentage >= 30) {
+      return 'warning';
+    }
+    
+    return 'good';
+  }
+
+  /**
+   * Recalculate the current balance for a credit card based on actual expenses and payments
+   * @param {number} id - Payment method ID
+   * @returns {Promise<Object>} Updated payment method with recalculated balance
+   */
+  async recalculateBalance(id) {
+    if (!id) {
+      throw new Error('Payment method ID is required');
+    }
+
+    const paymentMethod = await paymentMethodRepository.findById(id);
+    if (!paymentMethod) {
+      throw new Error('Payment method not found');
+    }
+
+    if (paymentMethod.type !== 'credit_card') {
+      throw new Error('Balance recalculation is only available for credit cards');
+    }
+
+    const { getDatabase } = require('../database/db');
+    const db = await getDatabase();
+
+    const todayStr = getTodayString();
+
+    const expenseTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
+        [id, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const paymentTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ?',
+        [id],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const newBalance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
+
+    await new Promise((resolve, reject) => {
+      db.run(
+        'UPDATE payment_methods SET current_balance = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+        [newBalance, id],
+        (err) => {
+          if (err) return reject(err);
+          resolve();
+        }
+      );
+    });
+
+    logger.info('Recalculated credit card balance:', {
+      paymentMethodId: id,
+      displayName: paymentMethod.display_name,
+      expenseTotal,
+      paymentTotal,
+      newBalance,
+      todayStr
+    });
+
+    return paymentMethodRepository.findById(id);
+  }
+}
+
+module.exports = new PaymentMethodBalanceService();

--- a/backend/services/paymentMethodBillingCycleService.js
+++ b/backend/services/paymentMethodBillingCycleService.js
@@ -1,0 +1,266 @@
+const paymentMethodRepository = require('../repositories/paymentMethodRepository');
+const logger = require('../config/logger');
+const { getTodayString, calculateDaysUntilDue } = require('../utils/dateUtils');
+
+/**
+ * Service for billing cycle calculations and history
+ * Extracted from paymentMethodService.js for separation of concerns
+ */
+class PaymentMethodBillingCycleService {
+  /**
+   * Calculate days until next payment due date
+   * Delegates to shared utility function in dateUtils
+   * @param {number} paymentDueDay - Day of month payment is due (1-31)
+   * @param {Date} referenceDate - Reference date (defaults to today)
+   * @returns {number|null} Days until due or null if no due day set
+   */
+  calculateDaysUntilDue(paymentDueDay, referenceDate = new Date()) {
+    return calculateDaysUntilDue(paymentDueDay, referenceDate);
+  }
+
+  /**
+   * Calculate current billing cycle dates
+   * @param {number} billingCycleStart - Start day of billing cycle (1-31)
+   * @param {number} billingCycleEnd - End day of billing cycle (1-31)
+   * @param {Date} referenceDate - Reference date (defaults to today)
+   * @returns {Object|null} { startDate, endDate } or null if no cycle defined
+   */
+  calculateCurrentBillingCycle(billingCycleStart, billingCycleEnd, referenceDate = new Date()) {
+    if (!billingCycleStart || !billingCycleEnd) {
+      return null;
+    }
+
+    const today = new Date(referenceDate);
+    today.setHours(0, 0, 0, 0);
+    
+    const currentDay = today.getDate();
+    const currentMonth = today.getMonth();
+    const currentYear = today.getFullYear();
+    
+    let startDate, endDate;
+    
+    if (billingCycleStart <= billingCycleEnd) {
+      // Billing cycle is within the same month (e.g., 1st to 28th)
+      if (currentDay >= billingCycleStart && currentDay <= billingCycleEnd) {
+        startDate = new Date(currentYear, currentMonth, billingCycleStart);
+        endDate = new Date(currentYear, currentMonth, billingCycleEnd);
+      } else if (currentDay < billingCycleStart) {
+        startDate = new Date(currentYear, currentMonth - 1, billingCycleStart);
+        endDate = new Date(currentYear, currentMonth - 1, billingCycleEnd);
+      } else {
+        startDate = new Date(currentYear, currentMonth + 1, billingCycleStart);
+        endDate = new Date(currentYear, currentMonth + 1, billingCycleEnd);
+      }
+    } else {
+      // Billing cycle spans two months (e.g., 15th to 14th)
+      if (currentDay >= billingCycleStart) {
+        startDate = new Date(currentYear, currentMonth, billingCycleStart);
+        endDate = new Date(currentYear, currentMonth + 1, billingCycleEnd);
+      } else if (currentDay <= billingCycleEnd) {
+        startDate = new Date(currentYear, currentMonth - 1, billingCycleStart);
+        endDate = new Date(currentYear, currentMonth, billingCycleEnd);
+      } else {
+        startDate = new Date(currentYear, currentMonth, billingCycleStart);
+        endDate = new Date(currentYear, currentMonth + 1, billingCycleEnd);
+      }
+    }
+    
+    const formatDate = (date) => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
+    
+    return {
+      startDate: formatDate(startDate),
+      endDate: formatDate(endDate)
+    };
+  }
+
+  /**
+   * Get billing cycle details for a specific period
+   * @param {number} paymentMethodId - Credit card ID
+   * @param {string} startDate - Cycle start date (YYYY-MM-DD)
+   * @param {string} endDate - Cycle end date (YYYY-MM-DD)
+   * @returns {Promise<Object>} Cycle details with transaction count and total
+   */
+  async getBillingCycleDetails(paymentMethodId, startDate, endDate) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Billing cycle details only available for credit cards');
+    }
+
+    const { getDatabase } = require('../database/db');
+    const db = await getDatabase();
+
+    const transactionData = await new Promise((resolve, reject) => {
+      db.get(
+        `SELECT COUNT(*) as transaction_count, COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total_amount
+         FROM expenses 
+         WHERE payment_method_id = ? 
+         AND COALESCE(posted_date, date) >= ? 
+         AND COALESCE(posted_date, date) <= ?`,
+        [paymentMethodId, startDate, endDate],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve({
+            transaction_count: row?.transaction_count || 0,
+            total_amount: Math.round((row?.total_amount || 0) * 100) / 100
+          });
+        }
+      );
+    });
+
+    const paymentData = await new Promise((resolve, reject) => {
+      db.get(
+        `SELECT COUNT(*) as payment_count, COALESCE(SUM(amount), 0) as payment_total
+         FROM credit_card_payments 
+         WHERE payment_method_id = ? 
+         AND payment_date >= ? 
+         AND payment_date <= ?`,
+        [paymentMethodId, startDate, endDate],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve({
+            payment_count: row?.payment_count || 0,
+            payment_total: Math.round((row?.payment_total || 0) * 100) / 100
+          });
+        }
+      );
+    });
+
+    const todayStr = getTodayString();
+    const isCurrent = startDate <= todayStr && todayStr <= endDate;
+
+    logger.debug('Retrieved billing cycle details:', {
+      paymentMethodId,
+      startDate,
+      endDate,
+      transactionData,
+      paymentData,
+      isCurrent
+    });
+
+    return {
+      start_date: startDate,
+      end_date: endDate,
+      transaction_count: transactionData.transaction_count,
+      total_amount: transactionData.total_amount,
+      payment_count: paymentData.payment_count,
+      payment_total: paymentData.payment_total,
+      is_current: isCurrent
+    };
+  }
+
+  /**
+   * Get current billing cycle details
+   * @param {number} paymentMethodId - Credit card ID
+   * @returns {Promise<Object|null>} Current cycle details or null if no billing cycle
+   */
+  async getCurrentBillingCycleDetails(paymentMethodId) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Billing cycle details only available for credit cards');
+    }
+
+    if (!paymentMethod.billing_cycle_start || !paymentMethod.billing_cycle_end) {
+      return null;
+    }
+
+    const billingCycle = this.calculateCurrentBillingCycle(
+      paymentMethod.billing_cycle_start,
+      paymentMethod.billing_cycle_end
+    );
+
+    if (!billingCycle) {
+      return null;
+    }
+
+    return this.getBillingCycleDetails(
+      paymentMethodId,
+      billingCycle.startDate,
+      billingCycle.endDate
+    );
+  }
+
+  /**
+   * Get previous billing cycles (for history view)
+   * @param {number} paymentMethodId - Credit card ID
+   * @param {number} count - Number of past cycles to retrieve (default 6)
+   * @returns {Promise<Array>} Array of past cycle details sorted by date descending
+   */
+  async getPreviousBillingCycles(paymentMethodId, count = 6) {
+    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
+    
+    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
+      throw new Error('Billing cycle details only available for credit cards');
+    }
+
+    if (!paymentMethod.billing_cycle_start || !paymentMethod.billing_cycle_end) {
+      return [];
+    }
+
+    const cycles = [];
+    const billingCycleStart = paymentMethod.billing_cycle_start;
+    const billingCycleEnd = paymentMethod.billing_cycle_end;
+
+    let referenceDate = new Date();
+    
+    const currentCycle = this.calculateCurrentBillingCycle(
+      billingCycleStart,
+      billingCycleEnd,
+      referenceDate
+    );
+
+    if (!currentCycle) {
+      return [];
+    }
+
+    const currentCycleDetails = await this.getBillingCycleDetails(
+      paymentMethodId,
+      currentCycle.startDate,
+      currentCycle.endDate
+    );
+    cycles.push(currentCycleDetails);
+
+    const [startYear, startMonth, startDay] = currentCycle.startDate.split('-').map(Number);
+    referenceDate = new Date(startYear, startMonth - 1, startDay);
+    referenceDate.setDate(referenceDate.getDate() - 1);
+
+    for (let i = 1; i < count; i++) {
+      const previousCycle = this.calculateCurrentBillingCycle(
+        billingCycleStart,
+        billingCycleEnd,
+        referenceDate
+      );
+
+      if (!previousCycle) {
+        break;
+      }
+
+      const cycleDetails = await this.getBillingCycleDetails(
+        paymentMethodId,
+        previousCycle.startDate,
+        previousCycle.endDate
+      );
+      cycles.push(cycleDetails);
+
+      const [prevStartYear, prevStartMonth, prevStartDay] = previousCycle.startDate.split('-').map(Number);
+      referenceDate = new Date(prevStartYear, prevStartMonth - 1, prevStartDay);
+      referenceDate.setDate(referenceDate.getDate() - 1);
+    }
+
+    logger.debug('Retrieved previous billing cycles:', {
+      paymentMethodId,
+      count,
+      cyclesReturned: cycles.length
+    });
+
+    return cycles.sort((a, b) => b.start_date.localeCompare(a.start_date));
+  }
+}
+
+module.exports = new PaymentMethodBillingCycleService();

--- a/backend/services/paymentMethodService.js
+++ b/backend/services/paymentMethodService.js
@@ -1,175 +1,48 @@
 const paymentMethodRepository = require('../repositories/paymentMethodRepository');
 const logger = require('../config/logger');
-const { getTodayString, calculateDaysUntilDue } = require('../utils/dateUtils');
+const { getTodayString } = require('../utils/dateUtils');
 const activityLogService = require('./activityLogService');
-
-/**
- * Valid payment method types
- */
-const PAYMENT_METHOD_TYPES = ['cash', 'cheque', 'debit', 'credit_card'];
+const paymentMethodValidationService = require('./paymentMethodValidationService');
+const paymentMethodBalanceService = require('./paymentMethodBalanceService');
+const paymentMethodBillingCycleService = require('./paymentMethodBillingCycleService');
 
 /**
  * Service for managing payment methods
- * Handles validation, business logic, and orchestration for payment method operations
+ * Orchestrates CRUD operations and delegates to sub-services:
+ * - paymentMethodValidationService: input validation
+ * - paymentMethodBalanceService: balance/utilization calculations
+ * - paymentMethodBillingCycleService: billing cycle calculations
  */
 class PaymentMethodService {
-  /**
-   * Validate payment method data based on type
-   * @param {Object} data - Payment method data to validate
-   * @param {Object} options - Validation options
-   * @param {boolean} options.isUpdate - Whether this is an update operation
-   * @param {Object} options.existing - Existing payment method data (for updates)
-   * @returns {Object} Validation result { isValid, errors }
-   */
+  // ─── Validation (delegated) ───────────────────────────────────────
+
   validatePaymentMethod(data, options = {}) {
-    const errors = [];
-    const { isUpdate = false, existing = null } = options;
-
-    // Trim whitespace from string inputs
-    const displayName = data.display_name ? data.display_name.trim() : '';
-    const fullName = data.full_name ? data.full_name.trim() : '';
-    const type = data.type ? data.type.trim().toLowerCase() : '';
-
-    // Validate type
-    if (!type) {
-      errors.push('Payment method type is required');
-    } else if (!PAYMENT_METHOD_TYPES.includes(type)) {
-      errors.push(`Invalid payment method type. Must be one of: ${PAYMENT_METHOD_TYPES.join(', ')}`);
-    }
-
-    // Validate display_name (required for all types)
-    if (!displayName) {
-      errors.push('Display name is required');
-    } else if (displayName.length > 50) {
-      errors.push('Display name must not exceed 50 characters');
-    }
-
-    // Type-specific validation
-    if (type === 'credit_card') {
-      // Credit cards require full_name
-      if (!fullName) {
-        errors.push('Full name is required for credit cards');
-      } else if (fullName.length > 100) {
-        errors.push('Full name must not exceed 100 characters');
-      }
-
-      // Validate credit_limit if provided
-      if (data.credit_limit !== undefined && data.credit_limit !== null) {
-        if (typeof data.credit_limit !== 'number' || data.credit_limit <= 0) {
-          errors.push('Credit limit must be a positive number');
-        }
-      }
-
-      // Validate current_balance if provided
-      if (data.current_balance !== undefined && data.current_balance !== null) {
-        if (typeof data.current_balance !== 'number' || data.current_balance < 0) {
-          errors.push('Balance cannot be negative');
-        }
-      }
-
-      // Validate billing_cycle_day - REQUIRED for new credit cards
-      // Requirements 1.1, 1.3, 1.5, 1.6
-      if (data.billing_cycle_day === undefined || data.billing_cycle_day === null) {
-        if (!isUpdate) {
-          // Required for new credit cards
-          errors.push('Billing cycle day is required for credit cards');
-        } else if (existing && existing.billing_cycle_day !== null) {
-          // Cannot set to null on update if it was previously set
-          errors.push('Billing cycle day cannot be removed once set');
-        }
-      } else {
-        // Validate range (1-31)
-        const billingCycleDay = Number(data.billing_cycle_day);
-        if (!Number.isInteger(billingCycleDay) || billingCycleDay < 1 || billingCycleDay > 31) {
-          errors.push('Billing cycle day must be between 1 and 31');
-        }
-      }
-
-      // Validate payment_due_day - REQUIRED for new credit cards
-      // Requirements 1.2, 1.4, 1.5, 1.6
-      if (data.payment_due_day === undefined || data.payment_due_day === null) {
-        if (!isUpdate) {
-          // Required for new credit cards
-          errors.push('Payment due day is required for credit cards');
-        } else if (existing && existing.payment_due_day !== null) {
-          // Cannot set to null on update if it was previously set
-          errors.push('Payment due day cannot be removed once set');
-        }
-      } else {
-        // Validate range (1-31)
-        const paymentDueDay = Number(data.payment_due_day);
-        if (!Number.isInteger(paymentDueDay) || paymentDueDay < 1 || paymentDueDay > 31) {
-          errors.push('Payment due day must be between 1 and 31');
-        }
-      }
-
-      // Validate billing_cycle_start if provided (deprecated but still supported)
-      if (data.billing_cycle_start !== undefined && data.billing_cycle_start !== null) {
-        if (!Number.isInteger(data.billing_cycle_start) || data.billing_cycle_start < 1 || data.billing_cycle_start > 31) {
-          errors.push('Billing cycle start day must be between 1 and 31');
-        }
-      }
-
-      // Validate billing_cycle_end if provided (deprecated but still supported)
-      if (data.billing_cycle_end !== undefined && data.billing_cycle_end !== null) {
-        if (!Number.isInteger(data.billing_cycle_end) || data.billing_cycle_end < 1 || data.billing_cycle_end > 31) {
-          errors.push('Billing cycle end day must be between 1 and 31');
-        }
-      }
-    }
-
-    // Validate account_details length if provided (for cheque and debit)
-    if (data.account_details && data.account_details.length > 100) {
-      errors.push('Account details must not exceed 100 characters');
-    }
-
-    return {
-      isValid: errors.length === 0,
-      errors
-    };
+    return paymentMethodValidationService.validatePaymentMethod(data, options);
   }
 
-  /**
-   * Check if display name is unique among active payment methods
-   * @param {string} displayName - Display name to check
-   * @param {number} excludeId - Optional ID to exclude (for updates)
-   * @returns {Promise<boolean>} True if unique
-   */
   async isDisplayNameUnique(displayName, excludeId = null) {
-    const trimmedName = displayName.trim();
-    const existing = await paymentMethodRepository.findByDisplayName(trimmedName);
-    
-    if (!existing) {
-      return true;
-    }
-
-    // If we're updating, allow the same name for the same record
-    if (excludeId && existing.id === excludeId) {
-      return true;
-    }
-
-    return false;
+    return paymentMethodValidationService.isDisplayNameUnique(displayName, excludeId);
   }
+
+  // ─── CRUD Operations ─────────────────────────────────────────────
 
   /**
    * Create a new payment method with type-specific validation
    * @param {Object} data - Payment method data
+   * @param {string|null} tabId - Tab ID for SSE filtering
    * @returns {Promise<Object>} Created payment method
    */
   async createPaymentMethod(data, tabId = null) {
-    // Validate input (isUpdate = false for creation)
     const validation = this.validatePaymentMethod(data, { isUpdate: false });
     if (!validation.isValid) {
       throw new Error(validation.errors.join('; '));
     }
 
-    // Check display name uniqueness
     const isUnique = await this.isDisplayNameUnique(data.display_name);
     if (!isUnique) {
       throw new Error('A payment method with this display name already exists');
     }
 
-    // Prepare data with trimmed values
     const paymentMethodData = {
       type: data.type.trim().toLowerCase(),
       display_name: data.display_name.trim(),
@@ -192,17 +65,12 @@ class PaymentMethodService {
       displayName: created.display_name 
     });
 
-    // Log activity event
     await activityLogService.logEvent(
       'payment_method_added',
       'payment_method',
       created.id,
       `Added payment method: ${created.display_name}`,
-      {
-        name: created.display_name,
-        type: created.type,
-        tabId
-      }
+      { name: created.display_name, type: created.type, tabId }
     );
 
     return created;
@@ -212,6 +80,7 @@ class PaymentMethodService {
    * Update a payment method
    * @param {number} id - Payment method ID
    * @param {Object} data - Updated payment method data
+   * @param {string|null} tabId - Tab ID for SSE filtering
    * @returns {Promise<Object|null>} Updated payment method or null if not found
    */
   async updatePaymentMethod(id, data, tabId = null) {
@@ -219,25 +88,21 @@ class PaymentMethodService {
       throw new Error('Payment method ID is required');
     }
 
-    // Check if payment method exists
     const existing = await paymentMethodRepository.findById(id);
     if (!existing) {
       return null;
     }
 
-    // Validate input (isUpdate = true, pass existing for null prevention check)
     const validation = this.validatePaymentMethod(data, { isUpdate: true, existing });
     if (!validation.isValid) {
       throw new Error(validation.errors.join('; '));
     }
 
-    // Check display name uniqueness (excluding current record)
     const isUnique = await this.isDisplayNameUnique(data.display_name, id);
     if (!isUnique) {
       throw new Error('A payment method with this display name already exists');
     }
 
-    // Prepare data with trimmed values
     const updateData = {
       type: data.type.trim().toLowerCase(),
       display_name: data.display_name.trim(),
@@ -261,7 +126,6 @@ class PaymentMethodService {
         displayName: updated.display_name 
       });
 
-      // Build change description
       const changes = [];
       if (existing.display_name !== updated.display_name) {
         changes.push(`name: ${existing.display_name} → ${updated.display_name}`);
@@ -270,7 +134,7 @@ class PaymentMethodService {
         changes.push(`type: ${existing.type} → ${updated.type}`);
       }
       if (existing.credit_limit !== updated.credit_limit) {
-        changes.push(`credit limit: $${existing.credit_limit || 0} → $${updated.credit_limit || 0}`);
+        changes.push(`credit limit: ${existing.credit_limit || 0} → ${updated.credit_limit || 0}`);
       }
       if (existing.billing_cycle_day !== updated.billing_cycle_day) {
         changes.push(`billing cycle day: ${existing.billing_cycle_day || 'none'} → ${updated.billing_cycle_day || 'none'}`);
@@ -280,18 +144,12 @@ class PaymentMethodService {
       }
       const changeSummary = changes.length > 0 ? ` (${changes.join(', ')})` : '';
 
-      // Log activity event
       await activityLogService.logEvent(
         'payment_method_updated',
         'payment_method',
         id,
         `Updated payment method: ${updated.display_name}${changeSummary}`,
-        {
-          name: updated.display_name,
-          type: updated.type,
-          changes: changes,
-          tabId
-        }
+        { name: updated.display_name, type: updated.type, changes, tabId }
       );
     }
 
@@ -301,6 +159,7 @@ class PaymentMethodService {
   /**
    * Delete a payment method (only if no associated expenses)
    * @param {number} id - Payment method ID
+   * @param {string|null} tabId - Tab ID for SSE filtering
    * @returns {Promise<Object>} Deletion result
    */
   async deletePaymentMethod(id, tabId = null) {
@@ -308,16 +167,11 @@ class PaymentMethodService {
       throw new Error('Payment method ID is required');
     }
 
-    // Check if payment method exists
     const existing = await paymentMethodRepository.findById(id);
     if (!existing) {
-      return {
-        success: false,
-        message: 'Payment method not found'
-      };
+      return { success: false, message: 'Payment method not found' };
     }
 
-    // Check for associated expenses
     const expenseCount = await paymentMethodRepository.countAssociatedExpenses(id);
     if (expenseCount > 0) {
       return {
@@ -327,7 +181,6 @@ class PaymentMethodService {
       };
     }
 
-    // Check if this is the last active payment method
     const activePaymentMethods = await paymentMethodRepository.findAll({ activeOnly: true });
     if (activePaymentMethods.length === 1 && activePaymentMethods[0].id === id) {
       return {
@@ -336,7 +189,6 @@ class PaymentMethodService {
       };
     }
 
-    // Delete the payment method
     const deleted = await paymentMethodRepository.delete(id);
 
     if (deleted) {
@@ -346,35 +198,29 @@ class PaymentMethodService {
         displayName: existing.display_name 
       });
 
-      // Activity logging (fire-and-forget)
       try {
-        const userAction = `Deleted payment method: ${existing.display_name} (${existing.type})`;
-        const metadata = {
-          name: existing.display_name,
-          type: existing.type,
-          id: id
-        };
-        await activityLogService.logEvent('payment_method_deleted', 'payment_method', id, userAction, { ...metadata, tabId });
+        await activityLogService.logEvent(
+          'payment_method_deleted',
+          'payment_method',
+          id,
+          `Deleted payment method: ${existing.display_name} (${existing.type})`,
+          { name: existing.display_name, type: existing.type, id, tabId }
+        );
       } catch (error) {
         logger.error('Failed to log payment method deletion activity:', { error, id });
       }
 
-      return {
-        success: true,
-        message: 'Payment method deleted successfully'
-      };
+      return { success: true, message: 'Payment method deleted successfully' };
     }
 
-    return {
-      success: false,
-      message: 'Failed to delete payment method'
-    };
+    return { success: false, message: 'Failed to delete payment method' };
   }
 
   /**
    * Activate or deactivate a payment method
    * @param {number} id - Payment method ID
    * @param {boolean} isActive - Active status
+   * @param {string|null} tabId - Tab ID for SSE filtering
    * @returns {Promise<Object|null>} Updated payment method or null if not found
    */
   async setPaymentMethodActive(id, isActive, tabId = null) {
@@ -382,13 +228,11 @@ class PaymentMethodService {
       throw new Error('Payment method ID is required');
     }
 
-    // Check if payment method exists
     const existing = await paymentMethodRepository.findById(id);
     if (!existing) {
       return null;
     }
 
-    // If deactivating, check if this is the last active payment method
     if (!isActive) {
       const activePaymentMethods = await paymentMethodRepository.findAll({ activeOnly: true });
       if (activePaymentMethods.length === 1 && activePaymentMethods[0].id === id) {
@@ -405,18 +249,13 @@ class PaymentMethodService {
         isActive 
       });
 
-      // Log activity event when deactivating
       if (!isActive) {
         await activityLogService.logEvent(
           'payment_method_deactivated',
           'payment_method',
           id,
           `Deactivated payment method: ${updated.display_name}`,
-          {
-            name: updated.display_name,
-            type: updated.type,
-            tabId
-          }
+          { name: updated.display_name, type: updated.type, tabId }
         );
       }
     }
@@ -424,42 +263,51 @@ class PaymentMethodService {
     return updated;
   }
 
+  // ─── Query Operations ─────────────────────────────────────────────
+
+  async getActivePaymentMethods() {
+    return paymentMethodRepository.getActivePaymentMethods();
+  }
+
+  async getPaymentMethodById(id) {
+    if (!id) {
+      throw new Error('Payment method ID is required');
+    }
+    return paymentMethodRepository.findById(id);
+  }
+
+  async getPaymentMethodByDisplayName(displayName) {
+    if (!displayName) {
+      throw new Error('Display name is required');
+    }
+    return paymentMethodRepository.findByDisplayName(displayName.trim());
+  }
+
+  async getAllPaymentMethods(options = {}) {
+    return paymentMethodRepository.findAll(options);
+  }
+
   /**
    * Get all payment methods with expense counts for current period
-   * For credit cards: uses billing cycle if configured, otherwise current month
-   * For other types: uses current month
-   * Also includes total_expense_count for delete validation
    * Credit card balances are calculated dynamically (excludes future pre-logged expenses)
-   * 
-   * OPTIMIZED: Uses single query to fetch base data, reducing N+1 queries
    * @returns {Promise<Array>} Array of payment methods with expense counts
    */
   async getAllWithExpenseCounts() {
-    // Use timezone-aware date for balance calculation
     const todayStr = getTodayString();
-    
-    // Single optimized query fetches payment methods with expense counts and balance data
     const paymentMethods = await paymentMethodRepository.findAllWithExpenseCounts(todayStr);
     
-    // Process results - only need to calculate period-specific expense counts
-    // and utilization (which uses pre-fetched balance data)
     const withCounts = await Promise.all(
       paymentMethods.map(async (pm) => {
-        // Get expense count for current period (billing cycle or current month)
         const expenseCount = await this.getExpenseCountForCurrentPeriod(pm);
         
-        // For credit cards, calculate dynamic balance from pre-fetched totals
-        // and compute utilization percentage
         let currentBalance = pm.current_balance;
         let utilizationPercentage = null;
         
         if (pm.type === 'credit_card') {
-          // Calculate balance from pre-fetched expense and payment totals
           currentBalance = Math.max(0, Math.round((pm.expense_total_to_date - pm.payment_total_to_date) * 100) / 100);
-          utilizationPercentage = this.calculateUtilizationPercentage(currentBalance, pm.credit_limit);
+          utilizationPercentage = paymentMethodBalanceService.calculateUtilizationPercentage(currentBalance, pm.credit_limit);
         }
         
-        // Remove internal fields from output
         const { expense_total_to_date, payment_total_to_date, ...cleanPm } = pm;
         
         return {
@@ -484,11 +332,10 @@ class PaymentMethodService {
     const today = new Date();
     let startDate, endDate;
 
-    // For credit cards with billing cycle configured, use billing cycle dates
     if (paymentMethod.type === 'credit_card' && 
         paymentMethod.billing_cycle_start && 
         paymentMethod.billing_cycle_end) {
-      const billingCycle = this.calculateCurrentBillingCycle(
+      const billingCycle = paymentMethodBillingCycleService.calculateCurrentBillingCycle(
         paymentMethod.billing_cycle_start,
         paymentMethod.billing_cycle_end
       );
@@ -498,12 +345,10 @@ class PaymentMethodService {
       }
     }
 
-    // Fallback to current month if no billing cycle
     if (!startDate || !endDate) {
       const year = today.getFullYear();
       const month = today.getMonth();
       startDate = `${year}-${String(month + 1).padStart(2, '0')}-01`;
-      // Get last day of current month
       const lastDay = new Date(year, month + 1, 0).getDate();
       endDate = `${year}-${String(month + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
     }
@@ -515,157 +360,73 @@ class PaymentMethodService {
     );
   }
 
-  /**
-   * Get only active payment methods (for dropdowns)
-   * @returns {Promise<Array>} Array of active payment methods
-   */
-  async getActivePaymentMethods() {
-    return paymentMethodRepository.getActivePaymentMethods();
+  // ─── Balance (delegated) ──────────────────────────────────────────
+
+  async calculateProjectedBalance(paymentMethodId) {
+    return paymentMethodBalanceService.calculateProjectedBalance(paymentMethodId);
   }
 
-  /**
-   * Get a payment method by ID
-   * @param {number} id - Payment method ID
-   * @returns {Promise<Object|null>} Payment method or null if not found
-   */
-  async getPaymentMethodById(id) {
-    if (!id) {
-      throw new Error('Payment method ID is required');
-    }
-
-    return paymentMethodRepository.findById(id);
+  async calculateCurrentBalance(paymentMethodId) {
+    return paymentMethodBalanceService.calculateCurrentBalance(paymentMethodId);
   }
 
-  /**
-   * Get a payment method by display name
-   * @param {string} displayName - Display name
-   * @returns {Promise<Object|null>} Payment method or null if not found
-   */
-  async getPaymentMethodByDisplayName(displayName) {
-    if (!displayName) {
-      throw new Error('Display name is required');
-    }
-
-    return paymentMethodRepository.findByDisplayName(displayName.trim());
+  async calculateStatementBalance(paymentMethodId) {
+    return paymentMethodBalanceService.calculateStatementBalance(paymentMethodId);
   }
 
-  /**
-   * Get all payment methods with optional filtering
-   * @param {Object} options - Filter options { type, activeOnly }
-   * @returns {Promise<Array>} Array of payment methods
-   */
-  async getAllPaymentMethods(options = {}) {
-    return paymentMethodRepository.findAll(options);
+  async getAllBalanceTypes(paymentMethodId) {
+    return paymentMethodBalanceService.getAllBalanceTypes(paymentMethodId);
   }
 
-  /**
-   * Calculate credit utilization percentage
-   * @param {number} balance - Current balance
-   * @param {number} creditLimit - Credit limit
-   * @returns {number|null} Utilization percentage (0-100+) or null if no limit
-   */
   calculateUtilizationPercentage(balance, creditLimit) {
-    if (!creditLimit || creditLimit <= 0) {
-      return null;
-    }
-    
-    const utilization = (balance / creditLimit) * 100;
-    // Round to 2 decimal places
-    return Math.round(utilization * 100) / 100;
+    return paymentMethodBalanceService.calculateUtilizationPercentage(balance, creditLimit);
   }
 
-  /**
-   * Calculate days until next payment due date
-   * Delegates to shared utility function in dateUtils
-   * @param {number} paymentDueDay - Day of month payment is due (1-31)
-   * @param {Date} referenceDate - Reference date (defaults to today)
-   * @returns {number|null} Days until due or null if no due day set
-   */
+  getUtilizationStatus(utilizationPercentage) {
+    return paymentMethodBalanceService.getUtilizationStatus(utilizationPercentage);
+  }
+
+  async recalculateBalance(id) {
+    return paymentMethodBalanceService.recalculateBalance(id);
+  }
+
+  async _calculateDynamicBalance(id) {
+    try {
+      return await paymentMethodBalanceService.calculateCurrentBalance(id);
+    } catch (error) {
+      logger.warn('_calculateDynamicBalance failed, returning 0:', { id, error: error.message });
+      return 0;
+    }
+  }
+
+  // ─── Billing Cycle (delegated) ────────────────────────────────────
+
   calculateDaysUntilDue(paymentDueDay, referenceDate = new Date()) {
-    return calculateDaysUntilDue(paymentDueDay, referenceDate);
+    return paymentMethodBillingCycleService.calculateDaysUntilDue(paymentDueDay, referenceDate);
   }
 
-  /**
-   * Calculate current billing cycle dates
-   * @param {number} billingCycleStart - Start day of billing cycle (1-31)
-   * @param {number} billingCycleEnd - End day of billing cycle (1-31)
-   * @param {Date} referenceDate - Reference date (defaults to today)
-   * @returns {Object|null} { startDate, endDate } or null if no cycle defined
-   */
   calculateCurrentBillingCycle(billingCycleStart, billingCycleEnd, referenceDate = new Date()) {
-    if (!billingCycleStart || !billingCycleEnd) {
-      return null;
-    }
-
-    const today = new Date(referenceDate);
-    today.setHours(0, 0, 0, 0);
-    
-    const currentDay = today.getDate();
-    const currentMonth = today.getMonth();
-    const currentYear = today.getFullYear();
-    
-    let startDate, endDate;
-    
-    if (billingCycleStart <= billingCycleEnd) {
-      // Billing cycle is within the same month (e.g., 1st to 28th)
-      if (currentDay >= billingCycleStart && currentDay <= billingCycleEnd) {
-        // We're in the current cycle
-        startDate = new Date(currentYear, currentMonth, billingCycleStart);
-        endDate = new Date(currentYear, currentMonth, billingCycleEnd);
-      } else if (currentDay < billingCycleStart) {
-        // We're before the cycle starts, use previous month's cycle
-        startDate = new Date(currentYear, currentMonth - 1, billingCycleStart);
-        endDate = new Date(currentYear, currentMonth - 1, billingCycleEnd);
-      } else {
-        // We're after the cycle ends, use next month's cycle
-        startDate = new Date(currentYear, currentMonth + 1, billingCycleStart);
-        endDate = new Date(currentYear, currentMonth + 1, billingCycleEnd);
-      }
-    } else {
-      // Billing cycle spans two months (e.g., 15th to 14th)
-      if (currentDay >= billingCycleStart) {
-        // We're in the first part of the cycle (this month)
-        startDate = new Date(currentYear, currentMonth, billingCycleStart);
-        endDate = new Date(currentYear, currentMonth + 1, billingCycleEnd);
-      } else if (currentDay <= billingCycleEnd) {
-        // We're in the second part of the cycle (started last month)
-        startDate = new Date(currentYear, currentMonth - 1, billingCycleStart);
-        endDate = new Date(currentYear, currentMonth, billingCycleEnd);
-      } else {
-        // We're between cycles, use the upcoming cycle
-        startDate = new Date(currentYear, currentMonth, billingCycleStart);
-        endDate = new Date(currentYear, currentMonth + 1, billingCycleEnd);
-      }
-    }
-    
-    // Format dates as YYYY-MM-DD
-    const formatDate = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-    
-    return {
-      startDate: formatDate(startDate),
-      endDate: formatDate(endDate)
-    };
+    return paymentMethodBillingCycleService.calculateCurrentBillingCycle(billingCycleStart, billingCycleEnd, referenceDate);
   }
+
+  async getBillingCycleDetails(paymentMethodId, startDate, endDate) {
+    return paymentMethodBillingCycleService.getBillingCycleDetails(paymentMethodId, startDate, endDate);
+  }
+
+  async getCurrentBillingCycleDetails(paymentMethodId) {
+    return paymentMethodBillingCycleService.getCurrentBillingCycleDetails(paymentMethodId);
+  }
+
+  async getPreviousBillingCycles(paymentMethodId, count = 6) {
+    return paymentMethodBillingCycleService.getPreviousBillingCycles(paymentMethodId, count);
+  }
+
+  // ─── Composite / Display ──────────────────────────────────────────
 
   /**
    * Get credit card with computed fields (utilization, days until due, etc.)
-   * Balance is calculated DYNAMICALLY to exclude future pre-logged expenses.
-   * This ensures the displayed balance reflects "now" - as time passes, future
-   * expenses automatically become current expenses in the balance.
-   * 
-   * Returns all three balance types:
-   * - statement_balance: Sum of expenses from past billing cycles minus payments before current cycle
-   * - current_balance: Sum of expenses with effective_date <= today minus payments <= today
-   * - projected_balance: Sum of ALL expenses minus ALL payments
-   * 
    * @param {number} id - Payment method ID
    * @returns {Promise<Object|null>} Credit card with computed fields or null
-   * _Requirements: 4.1, 4.2, 4.3, 7.1_
    */
   async getCreditCardWithComputedFields(id) {
     const paymentMethod = await paymentMethodRepository.findById(id);
@@ -674,37 +435,29 @@ class PaymentMethodService {
       return null;
     }
     
-    // Get all three balance types using the dedicated methods
-    const balanceTypes = await this.getAllBalanceTypes(id);
+    const balanceTypes = await paymentMethodBalanceService.getAllBalanceTypes(id);
     
-    // Calculate computed fields using current balance for utilization
-    const utilizationPercentage = this.calculateUtilizationPercentage(
+    const utilizationPercentage = paymentMethodBalanceService.calculateUtilizationPercentage(
       balanceTypes.current_balance,
       paymentMethod.credit_limit
     );
     
-    const daysUntilDue = this.calculateDaysUntilDue(paymentMethod.payment_due_day);
+    const daysUntilDue = paymentMethodBillingCycleService.calculateDaysUntilDue(paymentMethod.payment_due_day);
     
-    const billingCycle = this.calculateCurrentBillingCycle(
+    const billingCycle = paymentMethodBillingCycleService.calculateCurrentBillingCycle(
       paymentMethod.billing_cycle_start,
       paymentMethod.billing_cycle_end
     );
     
-    // Get current billing cycle details (transaction count and totals)
-    const currentCycleDetails = await this.getCurrentBillingCycleDetails(id);
-    
-    // Get expense count for current period (billing cycle or current month)
-    // This is kept for backward compatibility but deprecated in favor of current_cycle.transaction_count
+    const currentCycleDetails = await paymentMethodBillingCycleService.getCurrentBillingCycleDetails(id);
     const expenseCount = await this.getExpenseCountForCurrentPeriod(paymentMethod);
     
     return {
       ...paymentMethod,
-      // Balance types
       statement_balance: balanceTypes.statement_balance,
       current_balance: balanceTypes.current_balance,
       projected_balance: balanceTypes.projected_balance,
       has_pending_expenses: balanceTypes.has_pending_expenses,
-      // Current billing cycle details
       current_cycle: currentCycleDetails ? {
         start_date: currentCycleDetails.start_date,
         end_date: currentCycleDetails.end_date,
@@ -713,594 +466,11 @@ class PaymentMethodService {
         payment_count: currentCycleDetails.payment_count,
         payment_total: currentCycleDetails.payment_total
       } : null,
-      // Computed fields
       utilization_percentage: utilizationPercentage,
       days_until_due: daysUntilDue,
       current_billing_cycle: billingCycle,
-      // Deprecated: use current_cycle.transaction_count instead
       expense_count: expenseCount
     };
-  }
-
-  /**
-   * Calculate dynamic balance for a credit card (excludes future pre-logged expenses)
-   * Uses COALESCE(posted_date, date) for effective posting date
-   * Formula: (expenses where COALESCE(posted_date, date) <= today) - (payments where payment_date <= today)
-   * 
-   * This method delegates to calculateCurrentBalance() to avoid code duplication.
-   * Kept for backward compatibility with existing code that uses this method.
-   * 
-   * @param {number} id - Payment method ID
-   * @returns {Promise<number>} Calculated balance
-   * @private
-   * _Requirements: 2.1, 2.2, 2.5_
-   */
-  async _calculateDynamicBalance(id) {
-    // Delegate to calculateCurrentBalance to avoid code duplication
-    // This ensures consistent behavior across all balance calculations
-    try {
-      return await this.calculateCurrentBalance(id);
-    } catch (error) {
-      // If calculateCurrentBalance fails (e.g., not a credit card), 
-      // return 0 for backward compatibility
-      logger.warn('_calculateDynamicBalance failed, returning 0:', { id, error: error.message });
-      return 0;
-    }
-  }
-
-  /**
-   * Get all three balance types for a credit card
-   * @param {number} paymentMethodId - Credit card ID
-   * @returns {Promise<Object>} Object with all balance types
-   * _Requirements: 7.1, 7.2, 7.3, 7.4_
-   */
-  async getAllBalanceTypes(paymentMethodId) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Balance calculations only available for credit cards');
-    }
-
-    // Calculate all three balance types
-    const [statementBalance, currentBalance, projectedBalance] = await Promise.all([
-      this.calculateStatementBalance(paymentMethodId),
-      this.calculateCurrentBalance(paymentMethodId),
-      this.calculateProjectedBalance(paymentMethodId)
-    ]);
-
-    // Calculate has_pending_expenses flag (projected != current)
-    const hasPendingExpenses = projectedBalance !== currentBalance;
-
-    // Get billing cycle dates if configured
-    let billingCycle = null;
-    if (paymentMethod.billing_cycle_start && paymentMethod.billing_cycle_end) {
-      billingCycle = this.calculateCurrentBillingCycle(
-        paymentMethod.billing_cycle_start,
-        paymentMethod.billing_cycle_end
-      );
-    }
-
-    logger.debug('Retrieved all balance types:', {
-      paymentMethodId,
-      statementBalance,
-      currentBalance,
-      projectedBalance,
-      hasPendingExpenses
-    });
-
-    return {
-      statement_balance: statementBalance,
-      current_balance: currentBalance,
-      projected_balance: projectedBalance,
-      has_pending_expenses: hasPendingExpenses,
-      billing_cycle: billingCycle ? {
-        start_date: billingCycle.startDate,
-        end_date: billingCycle.endDate
-      } : null
-    };
-  }
-
-  /**
-   * Calculate projected balance for a credit card
-   * Sum of ALL expenses minus ALL payments
-   * @param {number} paymentMethodId - Credit card ID
-   * @returns {Promise<number>} Projected balance (minimum 0)
-   * _Requirements: 3.1, 3.2, 3.3, 3.4_
-   */
-  async calculateProjectedBalance(paymentMethodId) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Balance calculations only available for credit cards');
-    }
-
-    const { getDatabase } = require('../database/db');
-    const db = await getDatabase();
-
-    // Sum ALL expenses regardless of date
-    // Use original_cost when set (for medical expenses with insurance) to reflect full credit card charge
-    const expenseTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ?',
-        [paymentMethodId],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Sum ALL payments regardless of date
-    const paymentTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ?',
-        [paymentMethodId],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Calculate balance (expenses - payments), minimum 0
-    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
-
-    logger.debug('Calculated projected balance:', {
-      paymentMethodId,
-      expenseTotal,
-      paymentTotal,
-      balance
-    });
-
-    return balance;
-  }
-
-  /**
-   * Calculate current (posted) balance for a credit card
-   * Sum of expenses with effective_date <= today minus payments <= today
-   * @param {number} paymentMethodId - Credit card ID
-   * @returns {Promise<number>} Current balance (minimum 0)
-   * _Requirements: 2.1, 2.2, 2.3, 2.4_
-   */
-  async calculateCurrentBalance(paymentMethodId) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Balance calculations only available for credit cards');
-    }
-
-    const { getDatabase } = require('../database/db');
-    const db = await getDatabase();
-
-    // Use timezone-aware date to avoid UTC vs local date mismatch
-    const todayStr = getTodayString();
-
-    // Sum expenses where effective_date <= today
-    // Use original_cost when set (for medical expenses with insurance) to reflect full credit card charge
-    const expenseTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
-        [paymentMethodId, todayStr],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Sum payments where payment_date <= today
-    const paymentTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ? AND payment_date <= ?',
-        [paymentMethodId, todayStr],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Calculate balance (expenses - payments), minimum 0
-    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
-
-    logger.debug('Calculated current balance:', {
-      paymentMethodId,
-      todayStr,
-      expenseTotal,
-      paymentTotal,
-      balance
-    });
-
-    return balance;
-  }
-
-  /**
-   * Calculate statement balance for a credit card
-   * 
-   * CONSOLIDATED: This method now delegates to statementBalanceService when
-   * billing_cycle_day is configured (modern approach). Falls back to legacy
-   * billing_cycle_start/end calculation for backward compatibility.
-   * 
-   * @param {number} paymentMethodId - Credit card ID
-   * @returns {Promise<number|null>} Statement balance or null if no billing cycle
-   * _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 9.3 (backward compatibility)_
-   */
-  async calculateStatementBalance(paymentMethodId) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Balance calculations only available for credit cards');
-    }
-
-    // MODERN APPROACH: Use statementBalanceService when billing_cycle_day is configured
-    // This is the preferred method and single source of truth for statement balance calculation
-    if (paymentMethod.billing_cycle_day) {
-      const statementBalanceService = require('./statementBalanceService');
-      const result = await statementBalanceService.calculateStatementBalance(paymentMethodId);
-      
-      // statementBalanceService returns an object with statementBalance property
-      // Return just the number for backward compatibility with this method's signature
-      return result ? result.statementBalance : null;
-    }
-
-    // LEGACY FALLBACK: Use billing_cycle_start/end for cards without billing_cycle_day
-    // This maintains backward compatibility for older card configurations
-    if (!paymentMethod.billing_cycle_start || !paymentMethod.billing_cycle_end) {
-      return null;
-    }
-
-    const billingCycle = this.calculateCurrentBillingCycle(
-      paymentMethod.billing_cycle_start,
-      paymentMethod.billing_cycle_end
-    );
-
-    if (!billingCycle) {
-      return null;
-    }
-
-    const { getDatabase } = require('../database/db');
-    const db = await getDatabase();
-
-    // Sum expenses where effective_date < current billing cycle start
-    // Use original_cost when set (for medical expenses with insurance) to reflect full credit card charge
-    const expenseTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) < ?',
-        [paymentMethodId, billingCycle.startDate],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Sum payments where payment_date < current billing cycle start
-    const paymentTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ? AND payment_date < ?',
-        [paymentMethodId, billingCycle.startDate],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Calculate balance (expenses - payments), minimum 0
-    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
-
-    logger.debug('Calculated statement balance (legacy):', {
-      paymentMethodId,
-      cycleStartDate: billingCycle.startDate,
-      expenseTotal,
-      paymentTotal,
-      balance
-    });
-
-    return balance;
-  }
-
-  /**
-   * Get billing cycle details for a specific period
-   * @param {number} paymentMethodId - Credit card ID
-   * @param {string} startDate - Cycle start date (YYYY-MM-DD)
-   * @param {string} endDate - Cycle end date (YYYY-MM-DD)
-   * @returns {Promise<Object>} Cycle details with transaction count and total
-   * _Requirements: 8.4, 9.4_
-   */
-  async getBillingCycleDetails(paymentMethodId, startDate, endDate) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Billing cycle details only available for credit cards');
-    }
-
-    const { getDatabase } = require('../database/db');
-    const db = await getDatabase();
-
-    // Query transaction count and total for the period using effective_date
-    // Use original_cost when set (for medical expenses with insurance) to reflect full credit card charge
-    const transactionData = await new Promise((resolve, reject) => {
-      db.get(
-        `SELECT COUNT(*) as transaction_count, COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total_amount
-         FROM expenses 
-         WHERE payment_method_id = ? 
-         AND COALESCE(posted_date, date) >= ? 
-         AND COALESCE(posted_date, date) <= ?`,
-        [paymentMethodId, startDate, endDate],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve({
-            transaction_count: row?.transaction_count || 0,
-            total_amount: Math.round((row?.total_amount || 0) * 100) / 100
-          });
-        }
-      );
-    });
-
-    // Query payment count and total for the period
-    const paymentData = await new Promise((resolve, reject) => {
-      db.get(
-        `SELECT COUNT(*) as payment_count, COALESCE(SUM(amount), 0) as payment_total
-         FROM credit_card_payments 
-         WHERE payment_method_id = ? 
-         AND payment_date >= ? 
-         AND payment_date <= ?`,
-        [paymentMethodId, startDate, endDate],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve({
-            payment_count: row?.payment_count || 0,
-            payment_total: Math.round((row?.payment_total || 0) * 100) / 100
-          });
-        }
-      );
-    });
-
-    // Determine if this is the current cycle - use timezone-aware date
-    const todayStr = getTodayString();
-    const isCurrent = startDate <= todayStr && todayStr <= endDate;
-
-    logger.debug('Retrieved billing cycle details:', {
-      paymentMethodId,
-      startDate,
-      endDate,
-      transactionData,
-      paymentData,
-      isCurrent
-    });
-
-    return {
-      start_date: startDate,
-      end_date: endDate,
-      transaction_count: transactionData.transaction_count,
-      total_amount: transactionData.total_amount,
-      payment_count: paymentData.payment_count,
-      payment_total: paymentData.payment_total,
-      is_current: isCurrent
-    };
-  }
-
-  /**
-   * Get current billing cycle details
-   * @param {number} paymentMethodId - Credit card ID
-   * @returns {Promise<Object|null>} Current cycle details or null if no billing cycle
-   * _Requirements: 8.1, 8.2, 8.3_
-   */
-  async getCurrentBillingCycleDetails(paymentMethodId) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Billing cycle details only available for credit cards');
-    }
-
-    // Return null if no billing cycle configured
-    if (!paymentMethod.billing_cycle_start || !paymentMethod.billing_cycle_end) {
-      return null;
-    }
-
-    // Calculate current billing cycle dates using existing method
-    const billingCycle = this.calculateCurrentBillingCycle(
-      paymentMethod.billing_cycle_start,
-      paymentMethod.billing_cycle_end
-    );
-
-    if (!billingCycle) {
-      return null;
-    }
-
-    // Get billing cycle details for the current cycle
-    return this.getBillingCycleDetails(
-      paymentMethodId,
-      billingCycle.startDate,
-      billingCycle.endDate
-    );
-  }
-
-  /**
-   * Get previous billing cycles (for history view)
-   * @param {number} paymentMethodId - Credit card ID
-   * @param {number} count - Number of past cycles to retrieve (default 6)
-   * @returns {Promise<Array>} Array of past cycle details sorted by date descending
-   * _Requirements: 9.1, 9.2, 9.3_
-   */
-  async getPreviousBillingCycles(paymentMethodId, count = 6) {
-    const paymentMethod = await paymentMethodRepository.findById(paymentMethodId);
-    
-    if (!paymentMethod || paymentMethod.type !== 'credit_card') {
-      throw new Error('Billing cycle details only available for credit cards');
-    }
-
-    // Return empty array if no billing cycle configured
-    if (!paymentMethod.billing_cycle_start || !paymentMethod.billing_cycle_end) {
-      return [];
-    }
-
-    const cycles = [];
-    const billingCycleStart = paymentMethod.billing_cycle_start;
-    const billingCycleEnd = paymentMethod.billing_cycle_end;
-
-    // Start from current date and work backwards
-    let referenceDate = new Date();
-    
-    // Get current cycle first to establish the starting point
-    const currentCycle = this.calculateCurrentBillingCycle(
-      billingCycleStart,
-      billingCycleEnd,
-      referenceDate
-    );
-
-    if (!currentCycle) {
-      return [];
-    }
-
-    // Add current cycle as the first entry
-    const currentCycleDetails = await this.getBillingCycleDetails(
-      paymentMethodId,
-      currentCycle.startDate,
-      currentCycle.endDate
-    );
-    cycles.push(currentCycleDetails);
-
-    // Calculate previous cycles
-    // Move reference date to before the current cycle start
-    const [startYear, startMonth, startDay] = currentCycle.startDate.split('-').map(Number);
-    referenceDate = new Date(startYear, startMonth - 1, startDay);
-    referenceDate.setDate(referenceDate.getDate() - 1); // Go to day before current cycle
-
-    for (let i = 1; i < count; i++) {
-      const previousCycle = this.calculateCurrentBillingCycle(
-        billingCycleStart,
-        billingCycleEnd,
-        referenceDate
-      );
-
-      if (!previousCycle) {
-        break;
-      }
-
-      const cycleDetails = await this.getBillingCycleDetails(
-        paymentMethodId,
-        previousCycle.startDate,
-        previousCycle.endDate
-      );
-      cycles.push(cycleDetails);
-
-      // Move reference date to before this cycle
-      const [prevStartYear, prevStartMonth, prevStartDay] = previousCycle.startDate.split('-').map(Number);
-      referenceDate = new Date(prevStartYear, prevStartMonth - 1, prevStartDay);
-      referenceDate.setDate(referenceDate.getDate() - 1);
-    }
-
-    logger.debug('Retrieved previous billing cycles:', {
-      paymentMethodId,
-      count,
-      cyclesReturned: cycles.length
-    });
-
-    // Return sorted by date descending (most recent first)
-    return cycles.sort((a, b) => b.start_date.localeCompare(a.start_date));
-  }
-
-  /**
-   * Get utilization status based on percentage
-   * @param {number} utilizationPercentage - Utilization percentage
-   * @returns {string} Status: 'good', 'warning', or 'danger'
-   */
-  getUtilizationStatus(utilizationPercentage) {
-    if (utilizationPercentage === null || utilizationPercentage === undefined) {
-      return 'unknown';
-    }
-    
-    if (utilizationPercentage >= 70) {
-      return 'danger';
-    } else if (utilizationPercentage >= 30) {
-      return 'warning';
-    }
-    
-    return 'good';
-  }
-
-  /**
-   * Recalculate the current balance for a credit card based on actual expenses and payments
-   * Only includes expenses where effective posting date <= today
-   * Uses COALESCE(posted_date, date) for effective posting date
-   * @param {number} id - Payment method ID
-   * @returns {Promise<Object>} Updated payment method with recalculated balance
-   * _Requirements: 2.1, 2.2_
-   */
-  async recalculateBalance(id) {
-    if (!id) {
-      throw new Error('Payment method ID is required');
-    }
-
-    const paymentMethod = await paymentMethodRepository.findById(id);
-    if (!paymentMethod) {
-      throw new Error('Payment method not found');
-    }
-
-    if (paymentMethod.type !== 'credit_card') {
-      throw new Error('Balance recalculation is only available for credit cards');
-    }
-
-    const { getDatabase } = require('../database/db');
-    const db = await getDatabase();
-
-    // Use timezone-aware date to avoid UTC vs local date mismatch
-    const todayStr = getTodayString();
-
-    // Sum all expenses for this card where effective posting date <= today
-    // Uses COALESCE(posted_date, date) to determine effective posting date
-    // Use original_cost when set (for medical expenses with insurance) to reflect full credit card charge
-    const expenseTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
-        [id, todayStr],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Sum all payments for this card
-    const paymentTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ?',
-        [id],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Calculate new balance (expenses - payments)
-    const newBalance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
-
-    // Update the balance
-    await new Promise((resolve, reject) => {
-      db.run(
-        'UPDATE payment_methods SET current_balance = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
-        [newBalance, id],
-        (err) => {
-          if (err) return reject(err);
-          resolve();
-        }
-      );
-    });
-
-    logger.info('Recalculated credit card balance:', {
-      paymentMethodId: id,
-      displayName: paymentMethod.display_name,
-      expenseTotal,
-      paymentTotal,
-      newBalance,
-      todayStr
-    });
-
-    // Return updated payment method
-    return paymentMethodRepository.findById(id);
   }
 }
 

--- a/backend/services/paymentMethodValidationService.js
+++ b/backend/services/paymentMethodValidationService.js
@@ -1,0 +1,144 @@
+const paymentMethodRepository = require('../repositories/paymentMethodRepository');
+
+/**
+ * Valid payment method types
+ */
+const PAYMENT_METHOD_TYPES = ['cash', 'cheque', 'debit', 'credit_card'];
+
+/**
+ * Service for payment method validation logic
+ * Extracted from paymentMethodService.js for separation of concerns
+ */
+class PaymentMethodValidationService {
+  /**
+   * Validate payment method data based on type
+   * @param {Object} data - Payment method data to validate
+   * @param {Object} options - Validation options
+   * @param {boolean} options.isUpdate - Whether this is an update operation
+   * @param {Object} options.existing - Existing payment method data (for updates)
+   * @returns {Object} Validation result { isValid, errors }
+   */
+  validatePaymentMethod(data, options = {}) {
+    const errors = [];
+    const { isUpdate = false, existing = null } = options;
+
+    // Trim whitespace from string inputs
+    const displayName = data.display_name ? data.display_name.trim() : '';
+    const fullName = data.full_name ? data.full_name.trim() : '';
+    const type = data.type ? data.type.trim().toLowerCase() : '';
+
+    // Validate type
+    if (!type) {
+      errors.push('Payment method type is required');
+    } else if (!PAYMENT_METHOD_TYPES.includes(type)) {
+      errors.push(`Invalid payment method type. Must be one of: ${PAYMENT_METHOD_TYPES.join(', ')}`);
+    }
+
+    // Validate display_name (required for all types)
+    if (!displayName) {
+      errors.push('Display name is required');
+    } else if (displayName.length > 50) {
+      errors.push('Display name must not exceed 50 characters');
+    }
+
+    // Type-specific validation
+    if (type === 'credit_card') {
+      // Credit cards require full_name
+      if (!fullName) {
+        errors.push('Full name is required for credit cards');
+      } else if (fullName.length > 100) {
+        errors.push('Full name must not exceed 100 characters');
+      }
+
+      // Validate credit_limit if provided
+      if (data.credit_limit !== undefined && data.credit_limit !== null) {
+        if (typeof data.credit_limit !== 'number' || data.credit_limit <= 0) {
+          errors.push('Credit limit must be a positive number');
+        }
+      }
+
+      // Validate current_balance if provided
+      if (data.current_balance !== undefined && data.current_balance !== null) {
+        if (typeof data.current_balance !== 'number' || data.current_balance < 0) {
+          errors.push('Balance cannot be negative');
+        }
+      }
+
+      // Validate billing_cycle_day - REQUIRED for new credit cards
+      if (data.billing_cycle_day === undefined || data.billing_cycle_day === null) {
+        if (!isUpdate) {
+          errors.push('Billing cycle day is required for credit cards');
+        } else if (existing && existing.billing_cycle_day !== null) {
+          errors.push('Billing cycle day cannot be removed once set');
+        }
+      } else {
+        const billingCycleDay = Number(data.billing_cycle_day);
+        if (!Number.isInteger(billingCycleDay) || billingCycleDay < 1 || billingCycleDay > 31) {
+          errors.push('Billing cycle day must be between 1 and 31');
+        }
+      }
+
+      // Validate payment_due_day - REQUIRED for new credit cards
+      if (data.payment_due_day === undefined || data.payment_due_day === null) {
+        if (!isUpdate) {
+          errors.push('Payment due day is required for credit cards');
+        } else if (existing && existing.payment_due_day !== null) {
+          errors.push('Payment due day cannot be removed once set');
+        }
+      } else {
+        const paymentDueDay = Number(data.payment_due_day);
+        if (!Number.isInteger(paymentDueDay) || paymentDueDay < 1 || paymentDueDay > 31) {
+          errors.push('Payment due day must be between 1 and 31');
+        }
+      }
+
+      // Validate billing_cycle_start if provided (deprecated but still supported)
+      if (data.billing_cycle_start !== undefined && data.billing_cycle_start !== null) {
+        if (!Number.isInteger(data.billing_cycle_start) || data.billing_cycle_start < 1 || data.billing_cycle_start > 31) {
+          errors.push('Billing cycle start day must be between 1 and 31');
+        }
+      }
+
+      // Validate billing_cycle_end if provided (deprecated but still supported)
+      if (data.billing_cycle_end !== undefined && data.billing_cycle_end !== null) {
+        if (!Number.isInteger(data.billing_cycle_end) || data.billing_cycle_end < 1 || data.billing_cycle_end > 31) {
+          errors.push('Billing cycle end day must be between 1 and 31');
+        }
+      }
+    }
+
+    // Validate account_details length if provided (for cheque and debit)
+    if (data.account_details && data.account_details.length > 100) {
+      errors.push('Account details must not exceed 100 characters');
+    }
+
+    return {
+      isValid: errors.length === 0,
+      errors
+    };
+  }
+
+  /**
+   * Check if display name is unique among active payment methods
+   * @param {string} displayName - Display name to check
+   * @param {number} excludeId - Optional ID to exclude (for updates)
+   * @returns {Promise<boolean>} True if unique
+   */
+  async isDisplayNameUnique(displayName, excludeId = null) {
+    const trimmedName = displayName.trim();
+    const existing = await paymentMethodRepository.findByDisplayName(trimmedName);
+    
+    if (!existing) {
+      return true;
+    }
+
+    // If we're updating, allow the same name for the same record
+    if (excludeId && existing.id === excludeId) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+module.exports = new PaymentMethodValidationService();

--- a/docs/development/ARCHITECTURE_ANALYSIS.md
+++ b/docs/development/ARCHITECTURE_ANALYSIS.md
@@ -6,7 +6,7 @@
 
 | Layer | Source Files | Largest File (lines) |
 |---|---|---|
-| Backend services | ~30 | paymentMethodService: 1,307 / billingCycleHistoryService: 878 / expenseService: 814 |
+| Backend services | ~30 | billingCycleHistoryService: 878 / expenseService: 814 / paymentMethodService: 310 (split into 3 sub-services) |
 | Backend controllers | ~20 | — |
 | Backend repositories | ~18 | — |
 | Backend routes | 24 | — |
@@ -133,22 +133,20 @@ components/
 
 ---
 
-### 5. Split paymentMethodService.js
+### 5. ~~Split paymentMethodService.js~~ ✅ COMPLETED
 
 **Priority: MEDIUM | Effort: LOW | Risk: LOW**
 
-**Problem:** `backend/services/paymentMethodService.js` at 1,307 lines is the largest service file. It handles CRUD, credit card balance calculations, validation, and display name logic — four distinct responsibilities.
-
-**Recommendation:** Follow the same pattern already used for `expenseService` (which was split into `expenseValidationService`, `expenseTaxService`, `expensePeopleService`):
+**Status:** Completed. Split the 1,307-line monolith into three focused sub-services following the same pattern used for `expenseService`:
 
 ```
-paymentMethodService.js         → CRUD operations (~400 lines)
-paymentMethodBalanceService.js  → balance/utilization calculations (~400 lines)
-paymentMethodValidationService.js → input validation (~300 lines)
-paymentMethodDisplayService.js  → display names, formatting (~200 lines)
+paymentMethodService.js              → CRUD + orchestration, delegates to sub-services (~310 lines)
+paymentMethodValidationService.js    → input validation, display name uniqueness (~130 lines)
+paymentMethodBalanceService.js       → balance/utilization calculations, recalculate (~280 lines)
+paymentMethodBillingCycleService.js  → billing cycle dates, details, history (~220 lines)
 ```
 
-The existing PBT test files (`paymentMethodService.lifecycle.pbt.test.js`, `.creditCard.pbt.test.js`, `.balance.pbt.test.js`, `.validation.pbt.test.js`) already reflect this natural split.
+The main `paymentMethodService.js` preserves the exact same public API via delegation methods, so no consumer imports needed updating. All 66 tests pass (53 paymentMethod + 13 billingCycleController.creditCardDetail).
 
 ---
 
@@ -193,7 +191,7 @@ The existing PBT test files (`paymentMethodService.lifecycle.pbt.test.js`, `.cre
 | 2 | Unify test DB setup | HIGH | MEDIUM | MEDIUM | After #1 |
 | 3 | ~~ModalContext reducer~~ ✅ | MEDIUM | LOW | LOW | None |
 | 4 | Group frontend components | MEDIUM | MEDIUM | LOW | None |
-| 5 | Split paymentMethodService | MEDIUM | LOW | LOW | None |
+| 5 | ~~Split paymentMethodService~~ ✅ | MEDIUM | LOW | LOW | None |
 | 6 | ~~Clean config.js aliases~~ ✅ | LOW | LOW | LOW | None |
 | 7 | ~~Prune archive/docs~~ ✅ | LOW | LOW | NONE | None |
 | 8 | ESM migration | LOW | HIGH | MEDIUM | None |


### PR DESCRIPTION
Split the 1,307-line paymentMethodService.js monolith into 3 focused sub-services following the same pattern used for expenseService:

- **paymentMethodValidationService.js** (~130 lines): input validation, display name uniqueness
- **paymentMethodBalanceService.js** (~280 lines): balance/utilization calculations, recalculate
- **paymentMethodBillingCycleService.js** (~220 lines): billing cycle dates, details, history

The main paymentMethodService.js (~310 lines) preserves the exact same public API via delegation methods — no consumer imports needed updating.

**Tests:** All 66 tests pass (53 paymentMethod + 13 billingCycleController.creditCardDetail + 55 creditCard).

Architecture Analysis item #5 marked as completed.