### PR TITLE
feat: mortgage rate edit, rate history, projection payment fix

### DIFF
--- a/backend/services/mortgageInsightsService.js
+++ b/backend/services/mortgageInsightsService.js
@@ -7,6 +7,7 @@
 
 const loanRepository = require('../repositories/loanRepository');
 const loanBalanceRepository = require('../repositories/loanBalanceRepository');
+const fixedExpenseRepository = require('../repositories/fixedExpenseRepository');
 const mortgagePaymentService = require('./mortgagePaymentService');
 const mortgageService = require('./mortgageService');
 const { calculateMonthlyInterest } = require('../utils/interestCalculation');
@@ -372,10 +373,23 @@ class MortgageInsightsService {
       paymentFrequency: mortgage.payment_frequency || 'monthly'
     });
 
-    // Use current payment if set, otherwise use minimum payment as default
-    const currentPayment = currentPaymentEntry 
-      ? currentPaymentEntry.payment_amount 
-      : minimumPayment;
+    // Use current payment if set, otherwise check linked fixed expense, then fall back to minimum
+    let currentPayment;
+    let paymentSource = 'calculated';
+    if (currentPaymentEntry) {
+      currentPayment = currentPaymentEntry.payment_amount;
+      paymentSource = 'mortgage_payment';
+    } else {
+      // Check for linked fixed expense amount as a better fallback than calculated minimum
+      const linkedExpenses = await fixedExpenseRepository.getFixedExpensesByLoanId(mortgageId);
+      if (linkedExpenses && linkedExpenses.length > 0) {
+        currentPayment = linkedExpenses[0].amount;
+        paymentSource = 'linked_fixed_expense';
+      } else {
+        currentPayment = minimumPayment;
+        paymentSource = 'calculated';
+      }
+    }
 
     // Calculate interest breakdown
     const interestBreakdown = this.calculateInterestBreakdown(balance, rate);
@@ -396,12 +410,13 @@ class MortgageInsightsService {
     const dataStatus = {
       hasBalanceData: balanceHistory.length > 0,
       hasPaymentData: currentPaymentEntry !== null,
+      paymentSource,
       lastUpdated: currentBalanceEntry 
         ? `${currentBalanceEntry.year}-${String(currentBalanceEntry.month).padStart(2, '0')}`
         : null
     };
 
-    logger.debug('Generated mortgage insights:', { mortgageId, balance, rate, currentPayment });
+    logger.debug('Generated mortgage insights:', { mortgageId, balance, rate, currentPayment, paymentSource });
 
     return {
       mortgageId,

--- a/frontend/src/components/loans/MortgageTabbedContent.jsx
+++ b/frontend/src/components/loans/MortgageTabbedContent.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import useTabState from '../../hooks/useTabState';
 import styles from './MortgageTabbedContent.module.css';
 
@@ -144,8 +144,11 @@ function MortgageTabbedContent({
             loanData={loanData}
             calculatedBalanceData={calculatedBalanceData}
             linkedFixedExpenses={linkedFixedExpenses}
+            currentRate={currentRate}
+            balanceHistory={balanceHistory}
             loading={loading}
             onEditLoanDetails={onEditLoanDetails}
+            onEditRate={onEditRate}
             onMarkPaidOff={onMarkPaidOff}
           />
         )}
@@ -162,6 +165,7 @@ function MortgageTabbedContent({
           <ProjectionsPanel
             insights={insights}
             insightsLoading={insightsLoading}
+            linkedFixedExpenses={linkedFixedExpenses}
             onCalculateScenario={onCalculateScenario}
           />
         )}
@@ -197,14 +201,136 @@ function OverviewPanel({
   loanData,
   calculatedBalanceData,
   linkedFixedExpenses,
+  currentRate,
+  balanceHistory,
   loading,
   onEditLoanDetails,
+  onEditRate,
   onMarkPaidOff,
 }) {
+  const [isEditingRate, setIsEditingRate] = useState(false);
+  const [rateInput, setRateInput] = useState('');
+  const [rateError, setRateError] = useState(null);
+  const [rateSaving, setRateSaving] = useState(false);
+  const [showRateHistory, setShowRateHistory] = useState(false);
+
+  const handleStartEditRate = () => {
+    setRateInput(currentRate ? currentRate.toString() : '');
+    setRateError(null);
+    setIsEditingRate(true);
+  };
+
+  const handleSaveRate = async () => {
+    const parsed = parseFloat(rateInput);
+    if (isNaN(parsed) || parsed < 0 || parsed > 100) {
+      setRateError('Rate must be between 0 and 100');
+      return;
+    }
+    setRateSaving(true);
+    setRateError(null);
+    try {
+      await onEditRate(parsed);
+      setIsEditingRate(false);
+    } catch (err) {
+      setRateError(err.message || 'Failed to update rate');
+    } finally {
+      setRateSaving(false);
+    }
+  };
+
+  const handleCancelEditRate = () => {
+    setIsEditingRate(false);
+    setRateError(null);
+  };
+
+  // Build rate history from balance entries (unique rate changes)
+  const rateHistory = [];
+  if (balanceHistory?.length > 0) {
+    let lastRate = null;
+    // balanceHistory is sorted DESC (newest first), iterate in reverse for chronological order
+    const sorted = [...balanceHistory].sort((a, b) => {
+      if (a.year !== b.year) return a.year - b.year;
+      return a.month - b.month;
+    });
+    for (const entry of sorted) {
+      if (entry.rate !== lastRate) {
+        rateHistory.push({ year: entry.year, month: entry.month, rate: entry.rate });
+        lastRate = entry.rate;
+      }
+    }
+  }
+
   return (
     <div className={styles.overviewPanel}>
       {/* Requirement 4.1, 4.2 — MortgageDetailSection handles renewal banner internally */}
       <MortgageDetailSection mortgage={loanData} />
+
+      {/* Interest Rate section with inline edit */}
+      <div className={styles.section}>
+        <h4 className={styles.sectionHeading}>Interest Rate</h4>
+        {isEditingRate ? (
+          <div className={styles.rateEditRow}>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={rateInput}
+              onChange={(e) => setRateInput(e.target.value)}
+              className={styles.rateInput}
+              disabled={rateSaving}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSaveRate();
+                if (e.key === 'Escape') handleCancelEditRate();
+              }}
+            />
+            <span className={styles.rateInputSuffix}>%</span>
+            <button className={styles.rateBtn} onClick={handleSaveRate} disabled={rateSaving}>
+              {rateSaving ? '…' : '✓'}
+            </button>
+            <button className={styles.rateBtnCancel} onClick={handleCancelEditRate} disabled={rateSaving}>
+              ✕
+            </button>
+            {rateError && <span className={styles.rateError}>{rateError}</span>}
+          </div>
+        ) : (
+          <div className={styles.rateDisplayRow}>
+            <span className={styles.rateValue}>
+              {currentRate > 0 ? `${currentRate}%` : 'Not set'}
+            </span>
+            {loanData?.rate_type === 'variable' && (
+              <button className={styles.rateEditBtn} onClick={handleStartEditRate} disabled={loading}>
+                ✎ Update
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Rate history toggle */}
+        {rateHistory.length > 1 && (
+          <div className={styles.rateHistorySection}>
+            <button
+              className={styles.rateHistoryToggle}
+              onClick={() => setShowRateHistory(!showRateHistory)}
+            >
+              {showRateHistory ? '▾' : '▸'} Rate History ({rateHistory.length} changes)
+            </button>
+            {showRateHistory && (
+              <ul className={styles.rateHistoryList}>
+                {[...rateHistory].reverse().map((entry, idx) => (
+                  <li key={idx} className={styles.rateHistoryItem}>
+                    <span className={styles.rateHistoryDate}>
+                      {String(entry.month).padStart(2, '0')}/{entry.year}
+                    </span>
+                    <span className={styles.rateHistoryValue}>{entry.rate}%</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Requirement 4.3 — Linked fixed expenses */}
       {linkedFixedExpenses?.length > 0 && (
@@ -310,7 +436,7 @@ function ChartsPanel({ loanData, payments, balanceHistory, currentBalance, curre
 
 // ─── Projections Tab ─────────────────────────────────────────────────────────
 
-function ProjectionsPanel({ insights, insightsLoading, onCalculateScenario }) {
+function ProjectionsPanel({ insights, insightsLoading, linkedFixedExpenses, onCalculateScenario }) {
   // Requirement 6.4 — insufficient balance data message
   if (insights?.dataStatus?.hasBalanceData === false) {
     return (
@@ -320,8 +446,22 @@ function ProjectionsPanel({ insights, insightsLoading, onCalculateScenario }) {
     );
   }
 
+  // Show note if linked fixed expense amount differs from projection payment
+  const linkedPaymentAmount = linkedFixedExpenses?.length > 0 ? linkedFixedExpenses[0].amount : null;
+  const projectionPayment = insights?.currentStatus?.currentPayment;
+  const hasMismatch = linkedPaymentAmount != null && projectionPayment != null
+    && Math.abs(linkedPaymentAmount - projectionPayment) > 0.01;
+
   return (
     <div className={styles.projectionsPanel}>
+      {/* Payment source note */}
+      {hasMismatch && (
+        <div className={styles.paymentMismatchNote}>
+          <strong>Note:</strong> Your linked fixed expense is {formatCurrency(linkedPaymentAmount)}/mo 
+          but projections use {formatCurrency(projectionPayment)}/mo 
+          (from payment records). Update your mortgage payment record to align projections with your actual payment.
+        </div>
+      )}
       {/* Requirement 6.1 */}
       <PayoffProjectionInsights
         projections={insights?.projections}

--- a/frontend/src/components/loans/MortgageTabbedContent.module.css
+++ b/frontend/src/components/loans/MortgageTabbedContent.module.css
@@ -210,6 +210,149 @@
   gap: var(--spacing-5);
 }
 
+.paymentMismatchNote {
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--bg-warning, #fff8e1);
+  border: 1px solid var(--border-warning, #ffe082);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* ── Rate editing (Overview panel) ─────────────────────────────────────────── */
+.rateDisplayRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.rateValue {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+}
+
+.rateEditBtn {
+  padding: var(--spacing-1) var(--spacing-3);
+  font-size: var(--caption-text);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-button);
+}
+
+.rateEditBtn:hover {
+  background: var(--color-primary);
+  color: var(--text-inverse);
+}
+
+.rateEditRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.rateInput {
+  width: 80px;
+  padding: var(--spacing-2);
+  font-size: var(--text-base);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input, var(--bg-card));
+  color: var(--text-primary);
+}
+
+.rateInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
+}
+
+.rateInputSuffix {
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+}
+
+.rateBtn {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--text-base);
+  color: var(--text-inverse);
+  background: var(--color-positive);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 28px;
+}
+
+.rateBtnCancel {
+  padding: var(--spacing-1) var(--spacing-2);
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  min-width: 28px;
+}
+
+.rateError {
+  font-size: var(--caption-text);
+  color: var(--color-negative);
+  width: 100%;
+}
+
+/* Rate history */
+.rateHistorySection {
+  margin-top: var(--spacing-2);
+}
+
+.rateHistoryToggle {
+  padding: var(--spacing-1) 0;
+  font-size: var(--caption-text);
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.rateHistoryToggle:hover {
+  color: var(--text-primary);
+}
+
+.rateHistoryList {
+  list-style: none;
+  margin: var(--spacing-2) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.rateHistoryItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-1) var(--spacing-3);
+  background: var(--bg-muted);
+  border-radius: var(--radius-sm);
+  font-size: var(--caption-text);
+}
+
+.rateHistoryDate {
+  color: var(--text-secondary);
+}
+
+.rateHistoryValue {
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+}
+
 /* ── Payments panel ────────────────────────────────────────────────────────── */
 .paymentsPanel {
   display: flex;


### PR DESCRIPTION
- Add inline interest rate edit UI for variable-rate mortgages (Overview tab)
- Show rate history timeline from balance entries
- Fix projection payment source to use linked fixed expense amount
- Show mismatch note in Projections tab when amounts differ