### PR TITLE
Release v1.7.1: Add posted indicator icon on expense rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
 
 
 
+
+
+## [1.7.1] - 2026-05-07
+
+### Add posted indicator icon on expense rows
 ## [1.7.0] - 2026-05-06
 
 ### Mortgage rate edit, rate history, projection payment fix

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Full-stack Expense Tracker Application",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker-frontend",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Expense Tracker React Frontend",
   "type": "module",
   "private": true,

--- a/frontend/src/components/system/BackupSettings.jsx
+++ b/frontend/src/components/system/BackupSettings.jsx
@@ -1215,6 +1215,13 @@ const BackupSettings = () => {
             <h3>Recent Updates</h3>
             <div className="changelog">
               <div className="changelog-entry">
+                <div className="changelog-version">v1.7.1</div>
+                <div className="changelog-date">May 7, 2026</div>
+                <ul className="changelog-items">
+                  <li>Add posted indicator icon on expense rows</li>
+                </ul>
+              </div>
+              <div className="changelog-entry">
                 <div className="changelog-version">v1.7.0</div>
                 <div className="changelog-date">May 6, 2026</div>
                 <ul className="changelog-items">

--- a/frontend/src/components/system/SystemModal.jsx
+++ b/frontend/src/components/system/SystemModal.jsx
@@ -452,6 +452,16 @@ const SystemModal = () => {
           <div className="changelog">
             <div className="changelog-entry">
               <div className="changelog-version">
+                v1.7.1
+                {isCurrentVersion('v1.7.1') && <span className="current-version-badge">Current Version</span>}
+              </div>
+              <div className="changelog-date">May 7, 2026</div>
+              <ul className="changelog-items">
+                <li>Add posted indicator icon on expense rows</li>
+              </ul>
+            </div>
+            <div className="changelog-entry">
+              <div className="changelog-version">
                 v1.7.0
                 {isCurrentVersion('v1.7.0') && <span className="current-version-badge">Current Version</span>}
               </div>

--- a/frontend/src/utils/changelog.js
+++ b/frontend/src/utils/changelog.js
@@ -11,6 +11,14 @@
 
 const changelogEntries = [
   {
+    version: '1.7.1',
+    date: 'May 7, 2026',
+    added: [],
+    changed: ['Add posted indicator icon on expense rows'],
+    fixed: [],
+    removed: [],
+  },
+  {
     version: '1.7.0',
     date: 'May 6, 2026',
     added: [],


### PR DESCRIPTION
## Release v1.7.1

Add posted indicator icon on expense rows

### Version Bump
- Updated version in all 7 locations
- Frontend built

### Post-Merge Steps
After merging, the deploy script will:
1. Tag the merge commit`n2. Pull CI-built image from GHCR
3. Promote to staging → production