### PR TITLE
fix(loans): historical-balance discrepancy + loan/LOC audit fixes

### DIFF
--- a/.github/skills/expense-tracker-audit/SKILL.md
+++ b/.github/skills/expense-tracker-audit/SKILL.md
@@ -36,6 +36,20 @@ Past false positives on THIS repo:
   in `try/catch`. The real issue is a *smell* (see backend checklist), not a crash.
 - "LoanPaymentHistory conditional columns break table" — React renders nothing for
   `{false && <th>}`, and both thead/tbody exclude the column consistently. Valid.
+- "Unreachable controller catch branches for `Payment amount`/`Payment date`/
+  `Balance override`" — `loanPaymentService.validatePayment` DOES throw those exact
+  message prefixes, so the `error.message.includes(...)` branches in
+  `loanPaymentController` are reachable. Confirm the service's actual `throw` strings
+  before calling a branch dead.
+- "`autoPaymentLoggerService` builds dates without clamping the due day" — it DOES
+  clamp via `Math.min(dueDay, new Date(year, month, 0).getDate())`. Read the map()
+  body before flagging.
+- "`hasPaymentForMonth` uses `${year}-${month}-31` → invalid-date bug" — that's a
+  lexicographic STRING comparison upper bound against `YYYY-MM-DD` text columns
+  (`'2024-02-29' <= '2024-02-31'` holds), so it is correct, not a bug. Date-string
+  clamping only matters when the string is parsed into a `Date` or persisted.
+- "`LoanDetailView` doesn't reset form state on loan switch" — it DOES, in the
+  `isOpen && loan` effect (`setEditingPayment(null)`, `setShowPaymentForm(false)`).
 
 Past confirmed-true patterns on THIS repo:
 - Dead error-message branches left in catch blocks after feature-gate removal.
@@ -50,6 +64,21 @@ Past confirmed-true patterns on THIS repo:
 - Duplicate activity log events when a helper already logs and the caller logs again.
 - `editingPayment`/form state not reset in useEffect when the underlying entity
   (loan, expense) changes — stale form data from a previous entity persists.
+- Auto-log path bypasses the service layer: `autoPaymentLoggerService`.
+  `createPaymentFromFixedExpense` writes directly via `loanPaymentRepository.create()`
+  instead of `loanPaymentService.createPayment()`, so it SKIPS the mortgage
+  auto-snapshot step and the shared amount/date validation. This causes stale
+  `loan_balances` anchors → historical-balance discrepancies for mortgages linked to
+  fixed expenses. When auditing linked payments or balance drift, check whether the
+  write goes through the service or straight to the repository.
+- `parseFloat` guard drift between sibling controller actions: `createPayment` guards
+  `balanceOverride != null && !== ''` but `updatePayment` only checks `!== undefined`,
+  so an explicit `null` becomes `parseFloat(null)=NaN` and trips validation. Compare
+  create vs update handlers for the same optional field.
+- Inconsistent fire-and-forget `activityLogService.logEvent(...)`: some calls are
+  `await`ed, siblings are not and lack `.catch()` (e.g. `balance_override_applied`,
+  `auto_payment_logged`). Un-awaited + uncaught = unhandled rejection risk. Flag the
+  inconsistency, pick one convention.
 
 Downgrade or drop any finding you cannot reproduce by reading the source.
 

--- a/.github/skills/expense-tracker-audit/references/audit-checklist.md
+++ b/.github/skills/expense-tracker-audit/references/audit-checklist.md
@@ -59,6 +59,15 @@ Layer-specific, high-signal checks. Confirm each finding against source before r
 - [ ] LOC `currentBalance` is a snapshot from `loan_balances` table, NOT derived
       from payments. Any overpayment validation using this value would be incorrect
       for LOC — document/comment this semantic gap at the prop-passing site.
+- [ ] Auto-logging linked fixed-expense payments must go through
+      `loanPaymentService.createPayment` (not `loanPaymentRepository.create` directly).
+      The service performs the mortgage auto-snapshot + shared validation; bypassing it
+      leaves stale `loan_balances` anchors and causes historical-balance discrepancies
+      for mortgages. Check `autoPaymentLoggerService.createPaymentFromFixedExpense`.
+- [ ] Compare sibling controller actions (create vs update) for guard drift on the
+      same optional body field (e.g. `balanceOverride`): create may guard
+      `!= null && !== ''` while update only checks `!== undefined`, letting explicit
+      `null` reach `parseFloat(null) → NaN`.
 
 ## Frontend (React / Vite)
 

--- a/backend/controllers/loanPaymentController.js
+++ b/backend/controllers/loanPaymentController.js
@@ -147,7 +147,7 @@ async function updatePayment(req, res) {
       amount,
       payment_date,
       notes,
-      balanceOverride: balanceOverride !== undefined ? parseFloat(balanceOverride) : undefined
+      balanceOverride: balanceOverride != null && balanceOverride !== '' ? parseFloat(balanceOverride) : undefined
     });
     
     if (!updatedPayment) {

--- a/backend/services/autoPaymentLoggerService.js
+++ b/backend/services/autoPaymentLoggerService.js
@@ -12,6 +12,7 @@ const loanPaymentRepository = require('../repositories/loanPaymentRepository');
 const fixedExpenseRepository = require('../repositories/fixedExpenseRepository');
 const loanRepository = require('../repositories/loanRepository');
 const activityLogService = require('./activityLogService');
+const loanPaymentService = require('./loanPaymentService');
 const logger = require('../config/logger');
 
 /**
@@ -70,7 +71,12 @@ class AutoPaymentLoggerService {
       payment_date: paymentDate,
       notes: note
     });
-    
+
+    // Keep the mortgage interest-aware engine anchored to fresh data, matching the
+    // behavior of manually-logged payments (loanPaymentService.createPayment).
+    // Best-effort: never blocks the payment. No-op for non-mortgage loans.
+    await loanPaymentService.autoSnapshotMortgageBalance(loan, paymentDate);
+
     logger.info('Auto-logged loan payment from fixed expense:', {
       paymentId: payment.id,
       loanId: fixedExpense.linked_loan_id,
@@ -86,7 +92,7 @@ class AutoPaymentLoggerService {
     if (fixedExpense.fixed_expense_id !== undefined && fixedExpense.fixed_expense_id !== null) {
       eventMetadata.fixedExpenseId = fixedExpense.fixed_expense_id;
     }
-    activityLogService.logEvent(
+    await activityLogService.logEvent(
       'auto_payment_logged',
       'loan_payment',
       payment.id,

--- a/backend/services/loanPaymentService.js
+++ b/backend/services/loanPaymentService.js
@@ -78,6 +78,63 @@ class LoanPaymentService {
   }
 
   /**
+   * Create an auto-snapshot of a mortgage's balance after a payment so the
+   * interest-aware engine stays anchored to fresh data. No-op for non-mortgages
+   * and when the calculation is not interest-aware. Best-effort: failures are
+   * logged and swallowed so they never block payment creation.
+   *
+   * Shared by createPayment and the auto-payment logger so that payments created
+   * from linked fixed expenses get the same fresh anchor as manual payments.
+   * @param {Object} loan - Loan record (must include id, loan_type, fixed_interest_rate)
+   * @param {string} paymentDate - Payment date in YYYY-MM-DD format
+   */
+  async autoSnapshotMortgageBalance(loan, paymentDate) {
+    if (!loan || loan.loan_type !== 'mortgage') {
+      return;
+    }
+
+    try {
+      const calcResult = await balanceCalculationService.calculateBalance(loan.id, {
+        targetDate: paymentDate
+      });
+      if (calcResult.interestAware && calcResult.currentBalance != null) {
+        const date = new Date(paymentDate + 'T00:00:00Z');
+        const year = date.getUTCFullYear();
+        const month = date.getUTCMonth() + 1;
+
+        const snapshots = await loanBalanceRepository.getBalanceHistory(loan.id);
+        let rate = balanceCalculationService.resolveRateAtDate(snapshots, year, month);
+        if (rate == null && loan.fixed_interest_rate) {
+          rate = loan.fixed_interest_rate;
+        }
+        if (rate == null) {
+          rate = 0;
+        }
+
+        await loanBalanceService.createOrUpdateBalance({
+          loan_id: loan.id,
+          year,
+          month,
+          remaining_balance: calcResult.currentBalance,
+          rate
+        });
+
+        logger.debug('Auto-snapshot created after payment', {
+          loanId: loan.id,
+          balance: calcResult.currentBalance,
+          year,
+          month
+        });
+      }
+    } catch (err) {
+      logger.warn('Failed to auto-snapshot balance after payment', {
+        loanId: loan && loan.id,
+        error: err.message
+      });
+    }
+  }
+
+  /**
    * Create a new payment entry (Requirement 1.1)
    * @param {number} loanId - Loan ID
    * @param {Object} paymentData - { amount, payment_date, notes }
@@ -141,7 +198,7 @@ class LoanPaymentService {
       });
 
       // Log balance override event
-      activityLogService.logEvent(
+      await activityLogService.logEvent(
         'balance_override_applied',
         'loan_balance',
         loanId,
@@ -157,42 +214,7 @@ class LoanPaymentService {
     } else if (loan.loan_type === 'mortgage') {
       // Auto-snapshot: when no override is provided, calculate the balance at the
       // payment month and create a snapshot so the engine stays anchored to fresh data
-      try {
-        const calcResult = await balanceCalculationService.calculateBalance(loanId, {
-          targetDate: paymentData.payment_date
-        });
-        if (calcResult.interestAware && calcResult.currentBalance != null) {
-          const date = new Date(paymentData.payment_date + 'T00:00:00Z');
-          const year = date.getUTCFullYear();
-          const month = date.getUTCMonth() + 1;
-
-          const snapshots = await loanBalanceRepository.getBalanceHistory(loanId);
-          let rate = balanceCalculationService.resolveRateAtDate(snapshots, year, month);
-          if (rate == null && loan.fixed_interest_rate) {
-            rate = loan.fixed_interest_rate;
-          }
-          if (rate == null) {
-            rate = 0;
-          }
-
-          await loanBalanceService.createOrUpdateBalance({
-            loan_id: loanId,
-            year,
-            month,
-            remaining_balance: calcResult.currentBalance,
-            rate
-          });
-
-          logger.debug('Auto-snapshot created after payment', {
-            loanId,
-            balance: calcResult.currentBalance,
-            year,
-            month
-          });
-        }
-      } catch (err) {
-        logger.warn('Failed to auto-snapshot balance after payment', { loanId, error: err.message });
-      }
+      await this.autoSnapshotMortgageBalance(loan, paymentData.payment_date);
     }
     
     // Log the payment creation event

--- a/frontend/src/components/loans/LoanDetailView.jsx
+++ b/frontend/src/components/loans/LoanDetailView.jsx
@@ -221,7 +221,7 @@ const LoanDetailView = ({ loan, isOpen, onClose, onUpdate }) => {
     if (isOpen && loanData?.loan_type === 'mortgage') {
       fetchMortgageInsights();
     }
-  }, [isOpen, loanData?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isOpen, loanData?.id, loanData?.loan_type, fetchMortgageInsights]);
 
   // Handle mortgage payment edit - calls PUT /api/loans/:id/payments/:paymentId then re-fetches insights
   // Requirement 2.4, 2.5 — named handleMortgageEditPayment to avoid collision with existing handleEditPayment
@@ -1249,8 +1249,8 @@ const LoanDetailView = ({ loan, isOpen, onClose, onUpdate }) => {
               <LoanPaymentHistory
                 payments={payments}
                 initialBalance={
-                  calculatedBalanceData?.hasDiscrepancy && calculatedBalanceData?.actualBalance != null
-                    ? calculatedBalanceData.actualBalance + totalPayments
+                  calculatedBalanceData?.hasDiscrepancy
+                    ? currentBalance + totalPayments
                     : loanData.initial_balance
                 }
                 loading={loadingPayments}
@@ -1264,8 +1264,8 @@ const LoanDetailView = ({ loan, isOpen, onClose, onUpdate }) => {
                 <PaymentBalanceChart
                   payments={payments}
                   initialBalance={
-                    calculatedBalanceData?.hasDiscrepancy && calculatedBalanceData?.actualBalance != null
-                      ? calculatedBalanceData.actualBalance + totalPayments
+                    calculatedBalanceData?.hasDiscrepancy
+                      ? currentBalance + totalPayments
                       : loanData.initial_balance
                   }
                   loanName={loanData.name}

--- a/frontend/src/components/loans/MortgageTabbedContent.jsx
+++ b/frontend/src/components/loans/MortgageTabbedContent.jsx
@@ -529,8 +529,8 @@ function PaymentsPanel({
       <LoanPaymentHistory
         payments={payments}
         initialBalance={
-          calculatedBalanceData?.hasDiscrepancy && calculatedBalanceData?.actualBalance != null
-            ? calculatedBalanceData.actualBalance + (calculatedBalanceData.totalPayments || 0)
+          calculatedBalanceData?.hasDiscrepancy
+            ? currentBalance + (calculatedBalanceData.totalPayments || 0)
             : loanData?.initial_balance
         }
         loading={loadingPayments}

--- a/frontend/src/components/loans/TotalDebtView.jsx
+++ b/frontend/src/components/loans/TotalDebtView.jsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react';
 import './TotalDebtView.css';
 import { getTotalDebtOverTime } from '../../services/loanBalanceApi';
 import { formatCurrency, formatMonth } from '../../utils/formatters';
+import { createLogger } from '../../utils/logger';
+
+const logger = createLogger('TotalDebtView');
 
 const TotalDebtView = ({ isOpen, onClose }) => {
   const [debtHistory, setDebtHistory] = useState([]);
@@ -23,7 +26,7 @@ const TotalDebtView = ({ isOpen, onClose }) => {
       setDebtHistory(data || []);
     } catch (err) {
       setError(err.message || 'Failed to load total debt history');
-      console.error('Error fetching total debt history:', err);
+      logger.error('Error fetching total debt history:', err);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary

Fixes a historical-balance display discrepancy in the loan detail view and addresses verified findings from a focused audit of the loans / LOC / linked-fixed-expense-payment subsystem. Also updates the `expense-tracker-audit` skill with the learnings and newly-confirmed false positives.

## Changes

### Bug fixes
- **Historical-balance discrepancy (loan detail):** Payment History and `PaymentBalanceChart` now anchor to the real `currentBalance` instead of the stale `loan_balances` snapshot (`actualBalance`) for historical (`hasDiscrepancy`) loans. The Payment History "Current Balance" and the latest "Balance After" row now match the Loan Summary / Payment Tracking figures. (`LoanDetailView.jsx`, `MortgageTabbedContent.jsx`)
- **Auto-logged payment balance drift (High):** Auto-logged payments from linked fixed expenses previously wrote straight to the repository, skipping the mortgage auto-snapshot that keeps the interest-aware engine anchored — causing exactly the kind of stale-anchor discrepancy above. Extracted the snapshot logic into a shared `loanPaymentService.autoSnapshotMortgageBalance()` and invoked it from `autoPaymentLoggerService`, so auto-logged payments behave like manual ones. (No double activity-logging: the generic `loan_payment_added` event is not emitted; `auto_payment_logged` remains the sole event.)
- **`parseFloat` guard drift:** `updatePayment` now guards `balanceOverride` with `!= null && !== ''` to match `createPayment`, preventing `parseFloat(null) → NaN` from tripping spurious validation.

### Code smells
- Awaited previously fire-and-forget `activityLogService.logEvent` calls (`balance_override_applied`, `auto_payment_logged`) for consistency with `loan_payment_added`.
- `TotalDebtView.jsx`: replaced raw `console.error` with the shared `logger`.
- `LoanDetailView.jsx`: included `loan_type` / `fetchMortgageInsights` in the mortgage-insights effect deps and removed the `eslint-disable`.

### Docs
- Updated the `expense-tracker-audit` skill + checklist with verified patterns (service-bypass auto-log, create/update guard drift, fire-and-forget logging inconsistency) and four newly-confirmed false positives (reachable catch branches, clamped auto-log dates, lexicographic month-end cutoff, form-state reset).

## Testing
- Backend: `jest` for loanPayment / autoPaymentLogger / controller suites — **103 passed**.
- Frontend: `vitest` for LoanDetailView / MortgageTabbedContent / PaymentBalanceChart / LoanPaymentHistory suites — all passing.
