### PR TITLE
feat(frontend): modernize app shell with theme toggle + stabilize integration test

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,13 +12,14 @@
    Requirements: 10.1, 10.2, 10.3, 10.4
    ============================================ */
 .App-header {
-  background: linear-gradient(135deg, #1e293b 0%, #334155 50%, #475569 100%);
+  background: var(--header-bg);
   padding: var(--spacing-4) var(--spacing-6);
   color: var(--text-inverse);
   display: flex;
   justify-content: space-between;
   align-items: center;
   box-shadow: var(--shadow-md);
+  border-bottom: 1px solid var(--header-border);
   position: relative;
   z-index: var(--z-sticky);
 }
@@ -68,9 +69,9 @@
 
 .settings-button,
 .recurring-button {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--header-button-bg);
   color: var(--text-inverse);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--header-button-border);
   padding: var(--spacing-2) var(--spacing-4);
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
@@ -83,8 +84,8 @@
 
 .settings-button:hover,
 .recurring-button:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-  border-color: rgba(255, 255, 255, 0.3);
+  background-color: var(--header-button-bg-hover);
+  border-color: var(--header-button-border-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
@@ -100,6 +101,10 @@
 .recurring-button:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.5);
   outline-offset: 2px;
+}
+
+.theme-toggle-button {
+  min-width: 96px;
 }
 
 /* Accessibility: Respect reduced motion preferences for header */

--- a/frontend/src/App.integration.test.jsx
+++ b/frontend/src/App.integration.test.jsx
@@ -220,6 +220,9 @@ describe('App Integration Tests - Global Expense Filtering', () => {
 
     // Step 1: Apply payment method filter (Debit) - this triggers global view
     const paymentFilter = screen.getByLabelText(/filter by payment method/i);
+    await waitFor(() => {
+      expect(within(paymentFilter).getByRole('option', { name: 'Debit' })).toBeInTheDocument();
+    });
     await user.selectOptions(paymentFilter, 'Debit');
 
     // Should switch to global view and fetch all expenses

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -235,6 +235,22 @@ function AppContent({ onPaymentMethodsUpdate }) {
 
   const [versionInfo, setVersionInfo] = useState(null);
   const [mobileTab, setMobileTab] = useState('expenses'); // 'expenses' | 'summary'
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    const savedTheme = window.localStorage.getItem('theme-preference');
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      return savedTheme;
+    }
+
+    if (typeof window.matchMedia === 'function') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    return 'light';
+  });
   
   // Budget alerts state for Analytics Hub integration (Requirement 7.4)
   const [budgetAlerts, setBudgetAlerts] = useState([]);
@@ -264,6 +280,12 @@ function AppContent({ onPaymentMethodsUpdate }) {
       isMounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.style.colorScheme = theme;
+    window.localStorage.setItem('theme-preference', theme);
+  }, [theme]);
 
   // Fetch monthly income and budget alerts for Analytics Hub integration (Requirement 7.4)
   useEffect(() => {
@@ -362,6 +384,10 @@ function AppContent({ onPaymentMethodsUpdate }) {
     closeAnalyticsHub();
   }, [handleSearchChange, closeAnalyticsHub]);
 
+  const handleToggleTheme = useCallback(() => {
+    setTheme(prevTheme => (prevTheme === 'dark' ? 'light' : 'dark'));
+  }, []);
+
   return (
     <div className="App">
       <UpdateBanner
@@ -377,6 +403,14 @@ function AppContent({ onPaymentMethodsUpdate }) {
           <h1>Expense Tracker</h1>
         </div>
         <div className="header-buttons">
+          <button
+            className="settings-button theme-toggle-button"
+            onClick={handleToggleTheme}
+            aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+          >
+            {theme === 'dark' ? '☀️' : '🌙'} <span className="btn-text">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+          </button>
           <button 
             className="settings-button" 
             onClick={openSystemModal}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,7 +32,7 @@ body {
   font-size: var(--text-base);
   line-height: var(--leading-normal);
   color: var(--text-primary);
-  background: linear-gradient(135deg, #475569 0%, #334155 100%);
+  background: var(--bg-shell);
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/frontend/src/styles/variables.css
+++ b/frontend/src/styles/variables.css
@@ -198,6 +198,15 @@
   --bg-muted: #f1f5f9;
   --bg-subtle: #f8fafc;
   --bg-overlay: rgba(0, 0, 0, 0.5);
+   --bg-shell: linear-gradient(140deg, #e2e8f0 0%, #cbd5e1 45%, #94a3b8 100%);
+
+   /* App shell/header tokens */
+   --header-bg: rgba(15, 23, 42, 0.88);
+   --header-border: rgba(148, 163, 184, 0.35);
+   --header-button-bg: rgba(255, 255, 255, 0.1);
+   --header-button-border: rgba(255, 255, 255, 0.2);
+   --header-button-bg-hover: rgba(255, 255, 255, 0.2);
+   --header-button-border-hover: rgba(255, 255, 255, 0.3);
   
   /* Legacy aliases */
   --bg-light: var(--bg-page);
@@ -253,4 +262,36 @@
   --modal-width-md: 700px;
   --modal-width-lg: 900px;
   --modal-width-xl: 1200px;
+}
+
+:root[data-theme='dark'] {
+   --bg-page: #020617;
+   --bg-card: #0f172a;
+   --bg-card-hover: #16233a;
+   --bg-muted: #1e293b;
+   --bg-subtle: #0b1220;
+   --bg-overlay: rgba(2, 6, 23, 0.7);
+   --bg-shell: linear-gradient(140deg, #020617 0%, #0f172a 45%, #1e293b 100%);
+
+   --border-default: #334155;
+   --border-muted: #1e293b;
+   --border-strong: #475569;
+
+   --text-primary: #e2e8f0;
+   --text-secondary: #cbd5e1;
+   --text-tertiary: #94a3b8;
+   --text-muted: #64748b;
+   --text-light: #475569;
+   --text-inverse: #f8fafc;
+
+   --hover-overlay: rgba(148, 163, 184, 0.14);
+   --active-overlay: rgba(148, 163, 184, 0.22);
+   --focus-ring-offset: 0 0 0 2px var(--bg-card), 0 0 0 4px var(--color-primary);
+
+   --header-bg: rgba(2, 6, 23, 0.86);
+   --header-border: rgba(148, 163, 184, 0.24);
+   --header-button-bg: rgba(15, 23, 42, 0.8);
+   --header-button-border: rgba(148, 163, 184, 0.35);
+   --header-button-bg-hover: rgba(30, 41, 59, 0.95);
+   --header-button-border-hover: rgba(148, 163, 184, 0.55);
 }


### PR DESCRIPTION
## Summary
- add app-wide light/dark theme toggle in header with persisted preference
- add semantic shell/header tokens and dark theme overrides in variables
- replace hardcoded shell/header colors with token-driven styling
- switch global page background to shell token for consistent theming
- stabilize App integration workflow test by waiting for async payment method options before selecting

## Validation
- npx vitest --run src/App.integration.test.jsx
- npx vitest --run src/App.integration.test.jsx -t "should handle complete filter workflow: category"
- npm run build

## Notes
- This addresses the single frontend suite failure in App integration tests caused by selecting a payment method option before async options were loaded.
