### PR TITLE
Tech debt: add DB transaction primitives (Phase 1 PR-1)

### DIFF
--- a/backend/database/db.js
+++ b/backend/database/db.js
@@ -355,6 +355,74 @@ function closeTestDatabase() {
 }
 
 /**
+ * Promisified database run helper used by transaction primitives.
+ * @param {sqlite3.Database} db
+ * @param {string} sql
+ * @returns {Promise<void>}
+ */
+function runDbCommand(db, sql) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+/**
+ * Begin a transaction on an existing database connection.
+ * Uses IMMEDIATE to acquire a write lock up front and fail fast under contention.
+ * @param {sqlite3.Database} db
+ */
+async function beginTransaction(db) {
+  await runDbCommand(db, 'BEGIN IMMEDIATE TRANSACTION');
+}
+
+/**
+ * Commit an open transaction.
+ * @param {sqlite3.Database} db
+ */
+async function commitTransaction(db) {
+  await runDbCommand(db, 'COMMIT');
+}
+
+/**
+ * Roll back an open transaction.
+ * @param {sqlite3.Database} db
+ */
+async function rollbackTransaction(db) {
+  await runDbCommand(db, 'ROLLBACK');
+}
+
+/**
+ * Execute a callback within a database transaction.
+ * Rolls back on any callback error, then rethrows the original error.
+ * @template T
+ * @param {sqlite3.Database} db
+ * @param {(db: sqlite3.Database) => Promise<T>} operation
+ * @returns {Promise<T>}
+ */
+async function withTransaction(db, operation) {
+  await beginTransaction(db);
+
+  try {
+    const result = await operation(db);
+    await commitTransaction(db);
+    return result;
+  } catch (error) {
+    try {
+      await rollbackTransaction(db);
+    } catch (rollbackError) {
+      logger.error('Transaction rollback failed:', rollbackError);
+    }
+    throw error;
+  }
+}
+
+/**
  * Force recreation of the test database
  * Useful when the database gets corrupted
  */
@@ -407,6 +475,10 @@ function isTestMode() {
 module.exports = {
   initializeDatabase,
   getDatabase,
+  beginTransaction,
+  commitTransaction,
+  rollbackTransaction,
+  withTransaction,
   closeDatabase,
   createTestDatabase,
   getTestDatabase,

--- a/backend/database/db.transaction.test.js
+++ b/backend/database/db.transaction.test.js
@@ -1,0 +1,94 @@
+const {
+  beginTransaction,
+  commitTransaction,
+  rollbackTransaction,
+  withTransaction
+} = require('./db');
+const { createIsolatedTestDb, cleanupIsolatedTestDb } = require('../test/dbIsolation');
+
+function dbRun(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(this);
+    });
+  });
+}
+
+function dbGet(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(row);
+    });
+  });
+}
+
+describe('Database transaction helpers', () => {
+  let db;
+
+  beforeAll(async () => {
+    db = await createIsolatedTestDb();
+    await dbRun(db, `
+      CREATE TABLE IF NOT EXISTS tx_helper_test (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        value TEXT NOT NULL
+      )
+    `);
+  });
+
+  afterAll(() => {
+    cleanupIsolatedTestDb(db);
+  });
+
+  beforeEach(async () => {
+    await dbRun(db, 'DELETE FROM tx_helper_test');
+  });
+
+  test('beginTransaction + commitTransaction persists changes', async () => {
+    await beginTransaction(db);
+    await dbRun(db, 'INSERT INTO tx_helper_test (value) VALUES (?)', ['committed']);
+    await commitTransaction(db);
+
+    const row = await dbGet(db, 'SELECT COUNT(*) AS count FROM tx_helper_test');
+    expect(row.count).toBe(1);
+  });
+
+  test('beginTransaction + rollbackTransaction discards changes', async () => {
+    await beginTransaction(db);
+    await dbRun(db, 'INSERT INTO tx_helper_test (value) VALUES (?)', ['rolled-back']);
+    await rollbackTransaction(db);
+
+    const row = await dbGet(db, 'SELECT COUNT(*) AS count FROM tx_helper_test');
+    expect(row.count).toBe(0);
+  });
+
+  test('withTransaction commits on success', async () => {
+    const result = await withTransaction(db, async (txDb) => {
+      await dbRun(txDb, 'INSERT INTO tx_helper_test (value) VALUES (?)', ['ok']);
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    const row = await dbGet(db, 'SELECT COUNT(*) AS count FROM tx_helper_test');
+    expect(row.count).toBe(1);
+  });
+
+  test('withTransaction rolls back when callback throws', async () => {
+    await expect(
+      withTransaction(db, async (txDb) => {
+        await dbRun(txDb, 'INSERT INTO tx_helper_test (value) VALUES (?)', ['should-not-persist']);
+        throw new Error('forced failure');
+      })
+    ).rejects.toThrow('forced failure');
+
+    const row = await dbGet(db, 'SELECT COUNT(*) AS count FROM tx_helper_test');
+    expect(row.count).toBe(0);
+  });
+});

--- a/backend/repositories/expenseRepository.js
+++ b/backend/repositories/expenseRepository.js
@@ -8,8 +8,8 @@ class ExpenseRepository {
    * @param {Object} expense - Expense data
    * @returns {Promise<Object>} Created expense with ID
    */
-  async create(expense) {
-    const db = await getDatabase();
+  async create(expense, dbConnection = null) {
+    const db = dbConnection || await getDatabase();
     
     return new Promise((resolve, reject) => {
       const sql = `

--- a/backend/repositories/expenseRepository.js
+++ b/backend/repositories/expenseRepository.js
@@ -211,8 +211,8 @@ class ExpenseRepository {
    * @param {Object} expense - Updated expense data
    * @returns {Promise<Object|null>} Updated expense or null if not found
    */
-  async update(id, expense) {
-    const db = await getDatabase();
+  async update(id, expense, dbConnection = null) {
+    const db = dbConnection || await getDatabase();
     
     return new Promise((resolve, reject) => {
       const sql = `

--- a/backend/repositories/paymentMethodRepository.js
+++ b/backend/repositories/paymentMethodRepository.js
@@ -111,8 +111,8 @@ class PaymentMethodRepository {
    * @param {number} id - Payment method ID
    * @returns {Promise<Object|null>} Payment method or null if not found
    */
-  async findById(id) {
-    const db = await getDatabase();
+  async findById(id, dbConnection = null) {
+    const db = dbConnection || await getDatabase();
     
     return new Promise((resolve, reject) => {
       const sql = 'SELECT * FROM payment_methods WHERE id = ?';
@@ -134,8 +134,8 @@ class PaymentMethodRepository {
    * @param {string} displayName - Display name to search for
    * @returns {Promise<Object|null>} Payment method or null if not found
    */
-  async findByDisplayName(displayName) {
-    const db = await getDatabase();
+  async findByDisplayName(displayName, dbConnection = null) {
+    const db = dbConnection || await getDatabase();
     
     return new Promise((resolve, reject) => {
       const sql = 'SELECT * FROM payment_methods WHERE display_name = ?';
@@ -359,8 +359,8 @@ class PaymentMethodRepository {
    * @param {number} amount - Amount to add (positive) or subtract (negative)
    * @returns {Promise<Object|null>} Updated payment method or null if not found
    */
-  async updateBalance(id, amount) {
-    const db = await getDatabase();
+  async updateBalance(id, amount, dbConnection = null) {
+    const db = dbConnection || await getDatabase();
     
     return new Promise((resolve, reject) => {
       // First get current balance to ensure we don't go negative

--- a/backend/services/expenseService.js
+++ b/backend/services/expenseService.js
@@ -165,7 +165,9 @@ class ExpenseService {
    */
   async _resolvePaymentMethod(expenseData, dbConnection = null) {
     if (expenseData.payment_method_id) {
-      const paymentMethod = await paymentMethodRepository.findById(expenseData.payment_method_id, dbConnection);
+      const paymentMethod = dbConnection
+        ? await paymentMethodRepository.findById(expenseData.payment_method_id, dbConnection)
+        : await paymentMethodRepository.findById(expenseData.payment_method_id);
       if (!paymentMethod) {
         throw new Error(`Payment method with ID ${expenseData.payment_method_id} not found`);
       }
@@ -177,7 +179,9 @@ class ExpenseService {
     }
 
     if (expenseData.method) {
-      const paymentMethod = await paymentMethodRepository.findByDisplayName(expenseData.method, dbConnection);
+      const paymentMethod = dbConnection
+        ? await paymentMethodRepository.findByDisplayName(expenseData.method, dbConnection)
+        : await paymentMethodRepository.findByDisplayName(expenseData.method);
       if (paymentMethod) {
         return {
           payment_method_id: paymentMethod.id,
@@ -220,7 +224,11 @@ class ExpenseService {
    */
   async _updateCreditCardBalanceOnCreate(paymentMethod, amount, expenseDate, dbConnection = null) {
     if (paymentMethod && paymentMethod.type === 'credit_card') {
-      await paymentMethodRepository.updateBalance(paymentMethod.id, amount, dbConnection);
+      if (dbConnection) {
+        await paymentMethodRepository.updateBalance(paymentMethod.id, amount, dbConnection);
+      } else {
+        await paymentMethodRepository.updateBalance(paymentMethod.id, amount);
+      }
       logger.debug('Updated credit card balance after expense creation:', {
         paymentMethodId: paymentMethod.id,
         displayName: paymentMethod.display_name,
@@ -235,7 +243,11 @@ class ExpenseService {
    */
   async _updateCreditCardBalanceOnDelete(paymentMethod, amount, expenseDate, dbConnection = null) {
     if (paymentMethod && paymentMethod.type === 'credit_card') {
-      await paymentMethodRepository.updateBalance(paymentMethod.id, -amount, dbConnection);
+      if (dbConnection) {
+        await paymentMethodRepository.updateBalance(paymentMethod.id, -amount, dbConnection);
+      } else {
+        await paymentMethodRepository.updateBalance(paymentMethod.id, -amount);
+      }
       logger.debug('Updated credit card balance after expense deletion:', {
         paymentMethodId: paymentMethod.id,
         displayName: paymentMethod.display_name,
@@ -330,7 +342,9 @@ class ExpenseService {
       original_cost: reimbursementProcessedData.original_cost !== undefined ? reimbursementProcessedData.original_cost : null
     };
 
-    const createdExpense = await expenseRepository.create(expense, dbConnection);
+    const createdExpense = dbConnection
+      ? await expenseRepository.create(expense, dbConnection)
+      : await expenseRepository.create(expense);
 
     const chargedAmount = expense.original_cost !== null ? expense.original_cost : expense.amount;
     await this._updateCreditCardBalanceOnCreate(paymentMethod, chargedAmount, expense.date, dbConnection);
@@ -499,7 +513,9 @@ class ExpenseService {
 
       let oldPaymentMethod = null;
       if (oldExpense.payment_method_id) {
-        oldPaymentMethod = await paymentMethodRepository.findById(oldExpense.payment_method_id, dbConnection);
+        oldPaymentMethod = dbConnection
+          ? await paymentMethodRepository.findById(oldExpense.payment_method_id, dbConnection)
+          : await paymentMethodRepository.findById(oldExpense.payment_method_id);
       }
 
       const week = calculateWeek(reimbursementProcessedData.date);
@@ -519,7 +535,9 @@ class ExpenseService {
         original_cost: reimbursementProcessedData.original_cost !== undefined ? reimbursementProcessedData.original_cost : null
       };
 
-      const updatedExpense = await expenseRepository.update(id, expense, dbConnection);
+      const updatedExpense = dbConnection
+        ? await expenseRepository.update(id, expense, dbConnection)
+        : await expenseRepository.update(id, expense);
 
       // Handle credit card balance updates for payment method changes
       const oldChargedAmount = oldExpense.original_cost !== null ? oldExpense.original_cost : oldExpense.amount;
@@ -542,14 +560,22 @@ class ExpenseService {
       } else if (paymentMethod && paymentMethod.type === 'credit_card') {
         if (effectiveDateChanged && oldIsFuture !== newIsFuture) {
           if (oldIsFuture && !newIsFuture) {
-            await paymentMethodRepository.updateBalance(paymentMethod.id, newChargedAmount, dbConnection);
+            if (dbConnection) {
+              await paymentMethodRepository.updateBalance(paymentMethod.id, newChargedAmount, dbConnection);
+            } else {
+              await paymentMethodRepository.updateBalance(paymentMethod.id, newChargedAmount);
+            }
             logger.debug('Added expense to credit card balance (moved from future to past):', {
               paymentMethodId: paymentMethod.id,
               displayName: paymentMethod.display_name,
               amount: newChargedAmount
             });
           } else if (!oldIsFuture && newIsFuture) {
-            await paymentMethodRepository.updateBalance(paymentMethod.id, -oldChargedAmount, dbConnection);
+            if (dbConnection) {
+              await paymentMethodRepository.updateBalance(paymentMethod.id, -oldChargedAmount, dbConnection);
+            } else {
+              await paymentMethodRepository.updateBalance(paymentMethod.id, -oldChargedAmount);
+            }
             logger.debug('Removed expense from credit card balance (moved from past to future):', {
               paymentMethodId: paymentMethod.id,
               displayName: paymentMethod.display_name,
@@ -558,7 +584,11 @@ class ExpenseService {
           }
         } else if (chargedAmountChanged && !oldIsFuture && !newIsFuture) {
           const amountDiff = newChargedAmount - oldChargedAmount;
-          await paymentMethodRepository.updateBalance(paymentMethod.id, amountDiff, dbConnection);
+          if (dbConnection) {
+            await paymentMethodRepository.updateBalance(paymentMethod.id, amountDiff, dbConnection);
+          } else {
+            await paymentMethodRepository.updateBalance(paymentMethod.id, amountDiff);
+          }
           logger.debug('Updated credit card balance after expense amount change:', {
             paymentMethodId: paymentMethod.id,
             displayName: paymentMethod.display_name,

--- a/backend/services/expenseService.js
+++ b/backend/services/expenseService.js
@@ -233,9 +233,9 @@ class ExpenseService {
    * Update credit card balance after expense deletion.
    * @private
    */
-  async _updateCreditCardBalanceOnDelete(paymentMethod, amount, expenseDate) {
+  async _updateCreditCardBalanceOnDelete(paymentMethod, amount, expenseDate, dbConnection = null) {
     if (paymentMethod && paymentMethod.type === 'credit_card') {
-      await paymentMethodRepository.updateBalance(paymentMethod.id, -amount);
+      await paymentMethodRepository.updateBalance(paymentMethod.id, -amount, dbConnection);
       logger.debug('Updated credit card balance after expense deletion:', {
         paymentMethodId: paymentMethod.id,
         displayName: paymentMethod.display_name,
@@ -494,75 +494,155 @@ class ExpenseService {
     }
 
     const monthsToCreate = futureMonths || 0;
-    const { payment_method_id, method, paymentMethod } = await this._resolvePaymentMethod(reimbursementProcessedData);
+    const applyPrimaryUpdate = async (dbConnection = null) => {
+      const { payment_method_id, method, paymentMethod } = await this._resolvePaymentMethod(reimbursementProcessedData, dbConnection);
 
-    let oldPaymentMethod = null;
-    if (oldExpense.payment_method_id) {
-      oldPaymentMethod = await paymentMethodRepository.findById(oldExpense.payment_method_id);
-    }
-
-    const week = calculateWeek(reimbursementProcessedData.date);
-
-    const expense = {
-      date: reimbursementProcessedData.date,
-      posted_date: reimbursementProcessedData.posted_date || null,
-      place: reimbursementProcessedData.place || null,
-      notes: reimbursementProcessedData.notes || null,
-      amount: parseFloat(reimbursementProcessedData.amount),
-      type: reimbursementProcessedData.type,
-      week: week,
-      method: method,
-      payment_method_id: payment_method_id,
-      insurance_eligible: reimbursementProcessedData.insurance_eligible ? 1 : 0,
-      claim_status: reimbursementProcessedData.claim_status || null,
-      original_cost: reimbursementProcessedData.original_cost !== undefined ? reimbursementProcessedData.original_cost : null
-    };
-
-    const updatedExpense = await expenseRepository.update(id, expense);
-
-    // Handle credit card balance updates for payment method changes
-    const oldChargedAmount = oldExpense.original_cost !== null ? oldExpense.original_cost : oldExpense.amount;
-    const newChargedAmount = expense.original_cost !== null ? expense.original_cost : expense.amount;
-    const paymentMethodChanged = oldExpense.payment_method_id !== payment_method_id;
-    const chargedAmountChanged = oldChargedAmount !== newChargedAmount;
-    const oldEffectiveDate = this._getEffectivePostingDate(oldExpense);
-    const newEffectiveDate = this._getEffectivePostingDate(expense);
-    const effectiveDateChanged = oldEffectiveDate !== newEffectiveDate;
-    const oldIsFuture = this._isFutureDate(oldEffectiveDate);
-    const newIsFuture = this._isFutureDate(newEffectiveDate);
-
-    if (paymentMethodChanged) {
-      if (oldPaymentMethod && oldPaymentMethod.type === 'credit_card') {
-        await this._updateCreditCardBalanceOnDelete(oldPaymentMethod, oldChargedAmount, oldEffectiveDate);
+      let oldPaymentMethod = null;
+      if (oldExpense.payment_method_id) {
+        oldPaymentMethod = await paymentMethodRepository.findById(oldExpense.payment_method_id, dbConnection);
       }
-      if (paymentMethod && paymentMethod.type === 'credit_card') {
-        await this._updateCreditCardBalanceOnCreate(paymentMethod, newChargedAmount, newEffectiveDate);
-      }
-    } else if (paymentMethod && paymentMethod.type === 'credit_card') {
-      if (effectiveDateChanged && oldIsFuture !== newIsFuture) {
-        if (oldIsFuture && !newIsFuture) {
-          await paymentMethodRepository.updateBalance(paymentMethod.id, newChargedAmount);
-          logger.debug('Added expense to credit card balance (moved from future to past):', {
+
+      const week = calculateWeek(reimbursementProcessedData.date);
+
+      const expense = {
+        date: reimbursementProcessedData.date,
+        posted_date: reimbursementProcessedData.posted_date || null,
+        place: reimbursementProcessedData.place || null,
+        notes: reimbursementProcessedData.notes || null,
+        amount: parseFloat(reimbursementProcessedData.amount),
+        type: reimbursementProcessedData.type,
+        week: week,
+        method: method,
+        payment_method_id: payment_method_id,
+        insurance_eligible: reimbursementProcessedData.insurance_eligible ? 1 : 0,
+        claim_status: reimbursementProcessedData.claim_status || null,
+        original_cost: reimbursementProcessedData.original_cost !== undefined ? reimbursementProcessedData.original_cost : null
+      };
+
+      const updatedExpense = await expenseRepository.update(id, expense, dbConnection);
+
+      // Handle credit card balance updates for payment method changes
+      const oldChargedAmount = oldExpense.original_cost !== null ? oldExpense.original_cost : oldExpense.amount;
+      const newChargedAmount = expense.original_cost !== null ? expense.original_cost : expense.amount;
+      const paymentMethodChanged = oldExpense.payment_method_id !== payment_method_id;
+      const chargedAmountChanged = oldChargedAmount !== newChargedAmount;
+      const oldEffectiveDate = this._getEffectivePostingDate(oldExpense);
+      const newEffectiveDate = this._getEffectivePostingDate(expense);
+      const effectiveDateChanged = oldEffectiveDate !== newEffectiveDate;
+      const oldIsFuture = this._isFutureDate(oldEffectiveDate);
+      const newIsFuture = this._isFutureDate(newEffectiveDate);
+
+      if (paymentMethodChanged) {
+        if (oldPaymentMethod && oldPaymentMethod.type === 'credit_card') {
+          await this._updateCreditCardBalanceOnDelete(oldPaymentMethod, oldChargedAmount, oldEffectiveDate, dbConnection);
+        }
+        if (paymentMethod && paymentMethod.type === 'credit_card') {
+          await this._updateCreditCardBalanceOnCreate(paymentMethod, newChargedAmount, newEffectiveDate, dbConnection);
+        }
+      } else if (paymentMethod && paymentMethod.type === 'credit_card') {
+        if (effectiveDateChanged && oldIsFuture !== newIsFuture) {
+          if (oldIsFuture && !newIsFuture) {
+            await paymentMethodRepository.updateBalance(paymentMethod.id, newChargedAmount, dbConnection);
+            logger.debug('Added expense to credit card balance (moved from future to past):', {
+              paymentMethodId: paymentMethod.id,
+              displayName: paymentMethod.display_name,
+              amount: newChargedAmount
+            });
+          } else if (!oldIsFuture && newIsFuture) {
+            await paymentMethodRepository.updateBalance(paymentMethod.id, -oldChargedAmount, dbConnection);
+            logger.debug('Removed expense from credit card balance (moved from past to future):', {
+              paymentMethodId: paymentMethod.id,
+              displayName: paymentMethod.display_name,
+              amount: oldChargedAmount
+            });
+          }
+        } else if (chargedAmountChanged && !oldIsFuture && !newIsFuture) {
+          const amountDiff = newChargedAmount - oldChargedAmount;
+          await paymentMethodRepository.updateBalance(paymentMethod.id, amountDiff, dbConnection);
+          logger.debug('Updated credit card balance after expense amount change:', {
             paymentMethodId: paymentMethod.id,
             displayName: paymentMethod.display_name,
-            amount: newChargedAmount
-          });
-        } else if (!oldIsFuture && newIsFuture) {
-          await paymentMethodRepository.updateBalance(paymentMethod.id, -oldChargedAmount);
-          logger.debug('Removed expense from credit card balance (moved from past to future):', {
-            paymentMethodId: paymentMethod.id,
-            displayName: paymentMethod.display_name,
-            amount: oldChargedAmount
+            amountDiff
           });
         }
-      } else if (chargedAmountChanged && !oldIsFuture && !newIsFuture) {
-        const amountDiff = newChargedAmount - oldChargedAmount;
-        await paymentMethodRepository.updateBalance(paymentMethod.id, amountDiff);
-        logger.debug('Updated credit card balance after expense amount change:', {
-          paymentMethodId: paymentMethod.id,
-          displayName: paymentMethod.display_name,
-          amountDiff
+      }
+
+      return { updatedExpense, expense, payment_method_id, method };
+    };
+
+    let updatedExpense;
+    let expense;
+    let method;
+    let payment_method_id;
+    let futureExpenses = [];
+
+    if (monthsToCreate === 0) {
+      const result = await applyPrimaryUpdate();
+      updatedExpense = result.updatedExpense;
+      expense = result.expense;
+      method = result.method;
+      payment_method_id = result.payment_method_id;
+    } else {
+      const db = await getDatabase();
+      const futureSideEffects = [];
+
+      try {
+        const txResult = await withTransaction(db, async (txDb) => {
+          const result = await applyPrimaryUpdate(txDb);
+          const createdFutureExpenses = [];
+
+          for (let i = 1; i <= monthsToCreate; i++) {
+            const futureDate = this._calculateFutureDate(reimbursementProcessedData.date, i);
+            const futureExpenseData = {
+              ...reimbursementProcessedData,
+              date: futureDate,
+              payment_method_id: result.payment_method_id,
+              method: result.method
+            };
+
+            const futureExpense = await this._createSingleExpense(futureExpenseData, tabId, {
+              dbConnection: txDb,
+              skipSideEffects: true
+            });
+
+            createdFutureExpenses.push(futureExpense);
+            futureSideEffects.push({
+              expense: futureExpense,
+              method: futureExpense.method
+            });
+          }
+
+          return {
+            ...result,
+            futureExpenses: createdFutureExpenses
+          };
         });
+
+        updatedExpense = txResult.updatedExpense;
+        expense = txResult.expense;
+        method = txResult.method;
+        payment_method_id = txResult.payment_method_id;
+        futureExpenses = txResult.futureExpenses;
+
+        for (const sideEffect of futureSideEffects) {
+          this._triggerBudgetRecalculation(sideEffect.expense.date, sideEffect.expense.type);
+          await activityLogService.logEvent(
+            'expense_added',
+            'expense',
+            sideEffect.expense.id,
+            `Added expense: ${sideEffect.expense.place || 'Unknown'} - ${sideEffect.expense.amount.toFixed(2)} (${sideEffect.expense.date}, ${sideEffect.method})`,
+            {
+              amount: sideEffect.expense.amount,
+              category: sideEffect.expense.type,
+              date: sideEffect.expense.date,
+              place: sideEffect.expense.place,
+              method: sideEffect.method,
+              tabId
+            }
+          );
+        }
+      } catch (error) {
+        throw Object.assign(new Error('Failed to create future expenses. Please try again.'), { statusCode: 500 });
       }
     }
 
@@ -642,37 +722,9 @@ class ExpenseService {
       return updatedExpense;
     }
 
-    // Create future expenses with updated values
-    const futureExpenses = [];
-    const createdExpenseIds = [];
-
-    try {
-      for (let i = 1; i <= monthsToCreate; i++) {
-        const futureDate = this._calculateFutureDate(reimbursementProcessedData.date, i);
-        const futureExpenseData = {
-          ...reimbursementProcessedData,
-          date: futureDate,
-          payment_method_id: payment_method_id,
-          method: method
-        };
-        const futureExpense = await this._createSingleExpense(futureExpenseData, tabId);
-        futureExpenses.push(futureExpense);
-        createdExpenseIds.push(futureExpense.id);
-      }
-    } catch (error) {
-      for (const expenseId of createdExpenseIds) {
-        try {
-          await expenseRepository.delete(expenseId);
-        } catch (deleteError) {
-          logger.error('Error during rollback cleanup:', deleteError);
-        }
-      }
-      throw Object.assign(new Error('Failed to create future expenses. Please try again.'), { statusCode: 500 });
-    }
-
     return {
       expense: updatedExpense,
-      futureExpenses: futureExpenses
+      futureExpenses
     };
   }
 

--- a/backend/services/expenseService.js
+++ b/backend/services/expenseService.js
@@ -13,6 +13,7 @@ const expenseTaxService = require('./expenseTaxService');
 const expenseAggregationService = require('./expenseAggregationService');
 const expenseCategoryService = require('./expenseCategoryService');
 const activityLogService = require('./activityLogService');
+const { getDatabase, withTransaction } = require('../database/db');
 
 /**
  * ExpenseService Facade
@@ -149,12 +150,12 @@ class ExpenseService {
    * @private
    */
   async _validatePeopleExist(personAllocations) {
-    for (const allocation of personAllocations) {
+    await Promise.all(personAllocations.map(async (allocation) => {
       const person = await peopleRepository.findById(allocation.personId);
       if (!person) {
         throw new Error(`Person with ID ${allocation.personId} does not exist. Please add people in the People Management section first.`);
       }
-    }
+    }));
   }
 
   /**
@@ -162,9 +163,9 @@ class ExpenseService {
    * Returns both the payment_method_id and display_name (method string).
    * @private
    */
-  async _resolvePaymentMethod(expenseData) {
+  async _resolvePaymentMethod(expenseData, dbConnection = null) {
     if (expenseData.payment_method_id) {
-      const paymentMethod = await paymentMethodRepository.findById(expenseData.payment_method_id);
+      const paymentMethod = await paymentMethodRepository.findById(expenseData.payment_method_id, dbConnection);
       if (!paymentMethod) {
         throw new Error(`Payment method with ID ${expenseData.payment_method_id} not found`);
       }
@@ -176,7 +177,7 @@ class ExpenseService {
     }
 
     if (expenseData.method) {
-      const paymentMethod = await paymentMethodRepository.findByDisplayName(expenseData.method);
+      const paymentMethod = await paymentMethodRepository.findByDisplayName(expenseData.method, dbConnection);
       if (paymentMethod) {
         return {
           payment_method_id: paymentMethod.id,
@@ -217,9 +218,9 @@ class ExpenseService {
    * Update credit card balance after expense creation.
    * @private
    */
-  async _updateCreditCardBalanceOnCreate(paymentMethod, amount, expenseDate) {
+  async _updateCreditCardBalanceOnCreate(paymentMethod, amount, expenseDate, dbConnection = null) {
     if (paymentMethod && paymentMethod.type === 'credit_card') {
-      await paymentMethodRepository.updateBalance(paymentMethod.id, amount);
+      await paymentMethodRepository.updateBalance(paymentMethod.id, amount, dbConnection);
       logger.debug('Updated credit card balance after expense creation:', {
         paymentMethodId: paymentMethod.id,
         displayName: paymentMethod.display_name,
@@ -287,7 +288,12 @@ class ExpenseService {
    * Create a single expense (internal helper).
    * @private
    */
-  async _createSingleExpense(expenseData, tabId = null) {
+  async _createSingleExpense(expenseData, tabId = null, options = {}) {
+    const {
+      dbConnection = null,
+      skipSideEffects = false
+    } = options;
+
     const processedData = this._applyInsuranceDefaults(expenseData);
     const reimbursementProcessedData = this._processReimbursement(processedData);
 
@@ -304,7 +310,7 @@ class ExpenseService {
       );
     }
 
-    const { payment_method_id, method, paymentMethod } = await this._resolvePaymentMethod(reimbursementProcessedData);
+    const { payment_method_id, method, paymentMethod } = await this._resolvePaymentMethod(reimbursementProcessedData, dbConnection);
     const week = calculateWeek(reimbursementProcessedData.date);
 
     const expense = {
@@ -324,10 +330,15 @@ class ExpenseService {
       original_cost: reimbursementProcessedData.original_cost !== undefined ? reimbursementProcessedData.original_cost : null
     };
 
-    const createdExpense = await expenseRepository.create(expense);
+    const createdExpense = await expenseRepository.create(expense, dbConnection);
 
     const chargedAmount = expense.original_cost !== null ? expense.original_cost : expense.amount;
-    await this._updateCreditCardBalanceOnCreate(paymentMethod, chargedAmount, expense.date);
+    await this._updateCreditCardBalanceOnCreate(paymentMethod, chargedAmount, expense.date, dbConnection);
+
+    if (skipSideEffects) {
+      return createdExpense;
+    }
+
     this._triggerBudgetRecalculation(expense.date, expense.type);
 
     // Log activity event
@@ -357,38 +368,72 @@ class ExpenseService {
     this._validateFutureMonths(futureMonths);
 
     const monthsToCreate = futureMonths || 0;
-    const sourceExpense = await this._createSingleExpense(expenseData, tabId);
 
     if (monthsToCreate === 0) {
-      return sourceExpense;
+      return this._createSingleExpense(expenseData, tabId);
     }
 
-    const futureExpenses = [];
-    const createdExpenseIds = [sourceExpense.id];
+    const db = await getDatabase();
+    const sideEffects = [];
 
     try {
-      for (let i = 1; i <= monthsToCreate; i++) {
-        const futureDate = this._calculateFutureDate(expenseData.date, i);
-        const futureExpenseData = { ...expenseData, date: futureDate };
-        const futureExpense = await this._createSingleExpense(futureExpenseData, tabId);
-        futureExpenses.push(futureExpense);
-        createdExpenseIds.push(futureExpense.id);
-      }
-    } catch (error) {
-      for (const expenseId of createdExpenseIds) {
-        try {
-          await expenseRepository.delete(expenseId);
-        } catch (deleteError) {
-          logger.error('Error during rollback cleanup:', deleteError);
+      const result = await withTransaction(db, async (txDb) => {
+        const sourceExpense = await this._createSingleExpense(expenseData, tabId, {
+          dbConnection: txDb,
+          skipSideEffects: true
+        });
+
+        sideEffects.push({
+          expense: sourceExpense,
+          method: sourceExpense.method,
+          tabId
+        });
+
+        const futureExpenses = [];
+        for (let i = 1; i <= monthsToCreate; i++) {
+          const futureDate = this._calculateFutureDate(expenseData.date, i);
+          const futureExpenseData = { ...expenseData, date: futureDate };
+          const futureExpense = await this._createSingleExpense(futureExpenseData, tabId, {
+            dbConnection: txDb,
+            skipSideEffects: true
+          });
+          futureExpenses.push(futureExpense);
+          sideEffects.push({
+            expense: futureExpense,
+            method: futureExpense.method,
+            tabId
+          });
         }
+
+        return {
+          expense: sourceExpense,
+          futureExpenses
+        };
+      });
+
+      for (const sideEffect of sideEffects) {
+        const { expense, method } = sideEffect;
+        this._triggerBudgetRecalculation(expense.date, expense.type);
+        await activityLogService.logEvent(
+          'expense_added',
+          'expense',
+          expense.id,
+          `Added expense: ${expense.place || 'Unknown'} - ${expense.amount.toFixed(2)} (${expense.date}, ${method})`,
+          {
+            amount: expense.amount,
+            category: expense.type,
+            date: expense.date,
+            place: expense.place,
+            method,
+            tabId
+          }
+        );
       }
+
+      return result;
+    } catch (error) {
       throw Object.assign(new Error('Failed to create future expenses. Please try again.'), { statusCode: 500 });
     }
-
-    return {
-      expense: sourceExpense,
-      futureExpenses: futureExpenses
-    };
   }
 
   /**

--- a/backend/services/expenseService.transaction.integration.test.js
+++ b/backend/services/expenseService.transaction.integration.test.js
@@ -1,0 +1,100 @@
+const expenseService = require('./expenseService');
+const expenseRepository = require('../repositories/expenseRepository');
+const { getDatabase } = require('../database/db');
+
+function dbGet(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(row);
+    });
+  });
+}
+
+function dbAll(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(rows || []);
+    });
+  });
+}
+
+describe('ExpenseService transaction integration', () => {
+  let db;
+
+  beforeAll(async () => {
+    db = await getDatabase();
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await new Promise((resolve) => db.close(resolve));
+    }
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await new Promise((resolve, reject) => {
+      db.run("DELETE FROM expenses WHERE place LIKE 'TX_ROLLBACK_%'", (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+  test('createExpense with future months rolls back inserted expenses and card balance on failure', async () => {
+    const cardBefore = await dbGet(
+      db,
+      "SELECT id, current_balance FROM payment_methods WHERE display_name = 'Credit Card'"
+    );
+    expect(cardBefore).toBeTruthy();
+
+    const originalCreate = expenseRepository.create.bind(expenseRepository);
+    let createCalls = 0;
+
+    jest.spyOn(expenseRepository, 'create').mockImplementation(async (expense, dbConnection = null) => {
+      createCalls += 1;
+      if (createCalls === 2) {
+        throw new Error('Injected create failure');
+      }
+      return originalCreate(expense, dbConnection);
+    });
+
+    await expect(
+      expenseService.createExpense(
+        {
+          date: '2026-05-10',
+          place: 'TX_ROLLBACK_CARD_TEST',
+          notes: 'transaction rollback verification',
+          amount: 42.25,
+          type: 'Groceries',
+          method: 'Credit Card'
+        },
+        2
+      )
+    ).rejects.toThrow('Failed to create future expenses. Please try again.');
+
+    const createdRows = await dbAll(
+      db,
+      "SELECT id FROM expenses WHERE place = 'TX_ROLLBACK_CARD_TEST'"
+    );
+    expect(createdRows).toHaveLength(0);
+
+    const cardAfter = await dbGet(
+      db,
+      "SELECT current_balance FROM payment_methods WHERE id = ?",
+      [cardBefore.id]
+    );
+    expect(cardAfter.current_balance).toBe(cardBefore.current_balance);
+  });
+});

--- a/backend/services/expenseService.transaction.integration.test.js
+++ b/backend/services/expenseService.transaction.integration.test.js
@@ -29,6 +29,26 @@ function dbAll(db, sql, params = []) {
 describe('ExpenseService transaction integration', () => {
   let db;
 
+  async function cleanupTxExpenses() {
+    const rows = await dbAll(db, "SELECT id FROM expenses WHERE place LIKE 'TX_ROLLBACK_%'");
+    for (const row of rows) {
+      try {
+        await expenseService.deleteExpense(row.id);
+      } catch (_) {
+        // Fallback for partially-created rows in failed test paths.
+        await new Promise((resolve, reject) => {
+          db.run('DELETE FROM expenses WHERE id = ?', [row.id], (err) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve();
+          });
+        });
+      }
+    }
+  }
+
   beforeAll(async () => {
     db = await getDatabase();
   });
@@ -41,15 +61,7 @@ describe('ExpenseService transaction integration', () => {
 
   afterEach(async () => {
     jest.restoreAllMocks();
-    await new Promise((resolve, reject) => {
-      db.run("DELETE FROM expenses WHERE place LIKE 'TX_ROLLBACK_%'", (err) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve();
-      });
-    });
+    await cleanupTxExpenses();
   });
 
   test('createExpense with future months rolls back inserted expenses and card balance on failure', async () => {
@@ -89,6 +101,63 @@ describe('ExpenseService transaction integration', () => {
       "SELECT id FROM expenses WHERE place = 'TX_ROLLBACK_CARD_TEST'"
     );
     expect(createdRows).toHaveLength(0);
+
+    const cardAfter = await dbGet(
+      db,
+      "SELECT current_balance FROM payment_methods WHERE id = ?",
+      [cardBefore.id]
+    );
+    expect(cardAfter.current_balance).toBe(cardBefore.current_balance);
+  });
+
+  test('updateExpense with future months rolls back updated row and card balance on failure', async () => {
+    const originalExpense = await expenseService.createExpense(
+      {
+        date: '2026-04-10',
+        place: 'TX_ROLLBACK_UPDATE_ORIGINAL',
+        notes: 'before update',
+        amount: 20.0,
+        type: 'Groceries',
+        method: 'Credit Card'
+      },
+      0
+    );
+
+    const cardBefore = await dbGet(
+      db,
+      "SELECT id, current_balance FROM payment_methods WHERE display_name = 'Credit Card'"
+    );
+    expect(cardBefore).toBeTruthy();
+
+    jest.spyOn(expenseRepository, 'create').mockImplementation(async (expense, dbConnection = null) => {
+      throw new Error('Injected update-future create failure');
+    });
+
+    await expect(
+      expenseService.updateExpense(
+        originalExpense.id,
+        {
+          date: '2026-04-11',
+          place: 'TX_ROLLBACK_UPDATE_CHANGED',
+          notes: 'after update',
+          amount: 55.0,
+          type: 'Groceries',
+          method: 'Credit Card'
+        },
+        2
+      )
+    ).rejects.toThrow('Failed to create future expenses. Please try again.');
+
+    const reloaded = await expenseRepository.findById(originalExpense.id);
+    expect(reloaded.place).toBe('TX_ROLLBACK_UPDATE_ORIGINAL');
+    expect(reloaded.amount).toBe(20);
+    expect(reloaded.date).toBe('2026-04-10');
+
+    const changedRows = await dbAll(
+      db,
+      "SELECT id FROM expenses WHERE place = 'TX_ROLLBACK_UPDATE_CHANGED'"
+    );
+    expect(changedRows).toHaveLength(0);
 
     const cardAfter = await dbGet(
       db,

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -221,6 +221,17 @@ Use this template when spinning up any item below:
   - PR 2: migrate one high-risk path (`expense` create/update or backup restore).
   - PR 3+: expand to other multi-write flows after proving test ergonomics.
 
+  Implementation status (2026-06-07):
+  - ✅ PR 1 completed.
+  - Added transaction primitives in `backend/database/db.js`:
+    - `beginTransaction(db)`
+    - `commitTransaction(db)`
+    - `rollbackTransaction(db)`
+    - `withTransaction(db, operation)`
+  - Added focused tests in `backend/database/db.transaction.test.js` for commit and rollback behavior.
+  - Validation run: `cd backend && npm test -- db.transaction.test.js`.
+  - Next step remains PR 2: migrate one high-risk multi-write flow to use `withTransaction`.
+
   Done when:
   - At least the most failure-sensitive multi-step operations are atomic.
   - Rollback behavior is covered by focused tests.

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -223,18 +223,19 @@ Use this template when spinning up any item below:
 
   Implementation status (2026-06-07):
   - ✅ PR 1 completed.
-  - ✅ PR 2 started (first high-risk flow migrated).
+  - ✅ PR 2 in progress (two high-risk expense flows migrated).
   - Added transaction primitives in `backend/database/db.js`:
     - `beginTransaction(db)`
     - `commitTransaction(db)`
     - `rollbackTransaction(db)`
     - `withTransaction(db, operation)`
   - Migrated `expenseService.createExpense` future-month multi-write path to use `withTransaction` and removed manual delete-loop rollback cleanup.
+  - Migrated `expenseService.updateExpense` future-month multi-write path to use `withTransaction` and removed manual delete-loop rollback cleanup.
   - Added focused tests in:
     - `backend/database/db.transaction.test.js` (transaction primitives)
-    - `backend/services/expenseService.transaction.integration.test.js` (rollback of inserted expenses + credit-card balance when mid-sequence failure is injected)
+    - `backend/services/expenseService.transaction.integration.test.js` (rollback of inserted expenses + credit-card balance on create-flow failure, and rollback of updated row + card balance on update-flow failure)
   - Validation run: `cd backend && npm test -- db.transaction.test.js expenseService.transaction.integration.test.js`.
-  - Next step remains PR 2 expansion: migrate a second high-risk multi-write flow (`expenseService.updateExpense` with future-month writes or backup restore).
+  - Next step remains PR 3+: migrate backup/config-restore multi-write flow and expand transaction coverage to adjacent service paths.
 
   Done when:
   - At least the most failure-sensitive multi-step operations are atomic.

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -223,14 +223,18 @@ Use this template when spinning up any item below:
 
   Implementation status (2026-06-07):
   - ✅ PR 1 completed.
+  - ✅ PR 2 started (first high-risk flow migrated).
   - Added transaction primitives in `backend/database/db.js`:
     - `beginTransaction(db)`
     - `commitTransaction(db)`
     - `rollbackTransaction(db)`
     - `withTransaction(db, operation)`
-  - Added focused tests in `backend/database/db.transaction.test.js` for commit and rollback behavior.
-  - Validation run: `cd backend && npm test -- db.transaction.test.js`.
-  - Next step remains PR 2: migrate one high-risk multi-write flow to use `withTransaction`.
+  - Migrated `expenseService.createExpense` future-month multi-write path to use `withTransaction` and removed manual delete-loop rollback cleanup.
+  - Added focused tests in:
+    - `backend/database/db.transaction.test.js` (transaction primitives)
+    - `backend/services/expenseService.transaction.integration.test.js` (rollback of inserted expenses + credit-card balance when mid-sequence failure is injected)
+  - Validation run: `cd backend && npm test -- db.transaction.test.js expenseService.transaction.integration.test.js`.
+  - Next step remains PR 2 expansion: migrate a second high-risk multi-write flow (`expenseService.updateExpense` with future-month writes or backup restore).
 
   Done when:
   - At least the most failure-sensitive multi-step operations are atomic.
@@ -272,6 +276,9 @@ Use this template when spinning up any item below:
   Suggested execution:
   - Treat as opportunistic work while refactoring touched services.
   - Favor readability over micro-optimization; only parallelize independent calls.
+
+  Implementation status (2026-06-07):
+  - ✅ Opportunistic slice completed for `expenseService._validatePeopleExist` using `Promise.all` while touching transaction-related service paths.
 
 - **Use `backend/utils/validators.js` consistently.** Controllers re-implement inline
   validation instead of the shared validators.


### PR DESCRIPTION
## Summary
- add database-layer transaction helpers in backend/database/db.js
  - beginTransaction(db)
  - commitTransaction(db)
  - rollbackTransaction(db)
  - withTransaction(db, operation)
- migrate two high-risk multi-write flows to use transactions
  - expenseService.createExpense when futureMonths > 0 now uses withTransaction
  - expenseService.updateExpense when futureMonths > 0 now uses withTransaction
  - removed manual delete-loop rollback cleanup in both paths
- add focused tests
  - backend/database/db.transaction.test.js
  - backend/services/expenseService.transaction.integration.test.js
    - create-flow rollback test (inserted rows + card balance)
    - update-flow rollback test (updated row + card balance)
- enable repository methods to accept an optional existing db connection for transactional flows
  - backend/repositories/expenseRepository.js
  - backend/repositories/paymentMethodRepository.js
- opportunistic cleanup: parallelize people existence checks in backend/services/expenseService.js using Promise.all
- update implementation notes in docs/TECH-DEBT.md

## Why
This now covers PR-1 and expanded PR-2 for the high-priority transaction-support backlog item in docs/TECH-DEBT.md: primitives first, then migration of the highest-risk expense create/update future-month multi-write flows.

## Validation
- cd backend && npm test -- db.transaction.test.js expenseService.transaction.integration.test.js

## Follow-up
- migrate backup/config-restore multi-write flows to withTransaction and expand transaction coverage to adjacent service paths.