### PR TITLE
Anchor credit-card current balance to latest billing cycle

### DIFF
--- a/backend/services/paymentMethodBalanceService.js
+++ b/backend/services/paymentMethodBalanceService.js
@@ -1,4 +1,6 @@
 const paymentMethodRepository = require('../repositories/paymentMethodRepository');
+const billingCycleRepository = require('../repositories/billingCycleRepository');
+const { calculateEffectiveBalance } = require('../utils/effectiveBalanceUtil');
 const logger = require('../config/logger');
 const { getTodayString } = require('../utils/dateUtils');
 
@@ -78,37 +80,14 @@ class PaymentMethodBalanceService {
 
     const todayStr = getTodayString();
 
-    // Sum expenses where effective_date <= today
-    const expenseTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
-        [paymentMethodId, todayStr],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    // Sum payments where payment_date <= today
-    const paymentTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ? AND payment_date <= ?',
-        [paymentMethodId, todayStr],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    const balance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
+    // Prefer anchored current balance: latest closed-cycle effective balance
+    // plus net activity since cycle end. Fall back to all-time aggregation when
+    // no usable cycle anchor exists.
+    const balance = await this._calculateAnchoredCurrentBalance(db, paymentMethodId, todayStr);
 
     logger.debug('Calculated current balance:', {
       paymentMethodId,
       todayStr,
-      expenseTotal,
-      paymentTotal,
       balance
     });
 
@@ -297,30 +276,7 @@ class PaymentMethodBalanceService {
     const db = await getDatabase();
 
     const todayStr = getTodayString();
-
-    const expenseTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
-        [id, todayStr],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    const paymentTotal = await new Promise((resolve, reject) => {
-      db.get(
-        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ?',
-        [id],
-        (err, row) => {
-          if (err) return reject(err);
-          resolve(row?.total || 0);
-        }
-      );
-    });
-
-    const newBalance = Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
+    const newBalance = await this._calculateAnchoredCurrentBalance(db, id, todayStr);
 
     await new Promise((resolve, reject) => {
       db.run(
@@ -336,13 +292,92 @@ class PaymentMethodBalanceService {
     logger.info('Recalculated credit card balance:', {
       paymentMethodId: id,
       displayName: paymentMethod.display_name,
-      expenseTotal,
-      paymentTotal,
       newBalance,
       todayStr
     });
 
     return paymentMethodRepository.findById(id);
+  }
+
+  async _calculateAnchoredCurrentBalance(db, paymentMethodId, todayStr) {
+    const latestCycle = await billingCycleRepository.findByPaymentMethod(paymentMethodId, { limit: 1 });
+    const anchorCycle = Array.isArray(latestCycle) && latestCycle.length > 0 ? latestCycle[0] : null;
+
+    // No anchor available: retain legacy all-time behavior.
+    if (!anchorCycle || !anchorCycle.cycle_end_date) {
+      return this._calculateLegacyCurrentBalance(db, paymentMethodId, todayStr);
+    }
+
+    const { effectiveBalance } = calculateEffectiveBalance(anchorCycle);
+
+    const expenseDelta = await new Promise((resolve, reject) => {
+      db.get(
+        `SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total
+         FROM expenses
+         WHERE payment_method_id = ?
+           AND COALESCE(posted_date, date) > ?
+           AND COALESCE(posted_date, date) <= ?`,
+        [paymentMethodId, anchorCycle.cycle_end_date, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const paymentDelta = await new Promise((resolve, reject) => {
+      db.get(
+        `SELECT COALESCE(SUM(amount), 0) as total
+         FROM credit_card_payments
+         WHERE payment_method_id = ?
+           AND payment_date > ?
+           AND payment_date <= ?`,
+        [paymentMethodId, anchorCycle.cycle_end_date, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const anchored = Math.max(0, Math.round((effectiveBalance + expenseDelta - paymentDelta) * 100) / 100);
+
+    logger.debug('Calculated anchored current balance:', {
+      paymentMethodId,
+      anchorCycleEndDate: anchorCycle.cycle_end_date,
+      anchorEffectiveBalance: effectiveBalance,
+      expenseDelta,
+      paymentDelta,
+      anchored
+    });
+
+    return anchored;
+  }
+
+  async _calculateLegacyCurrentBalance(db, paymentMethodId, todayStr) {
+    const expenseTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total FROM expenses WHERE payment_method_id = ? AND COALESCE(posted_date, date) <= ?',
+        [paymentMethodId, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    const paymentTotal = await new Promise((resolve, reject) => {
+      db.get(
+        'SELECT COALESCE(SUM(amount), 0) as total FROM credit_card_payments WHERE payment_method_id = ? AND payment_date <= ?',
+        [paymentMethodId, todayStr],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(row?.total || 0);
+        }
+      );
+    });
+
+    return Math.max(0, Math.round((expenseTotal - paymentTotal) * 100) / 100);
   }
 }
 

--- a/backend/services/paymentMethodService.js
+++ b/backend/services/paymentMethodService.js
@@ -304,7 +304,7 @@ class PaymentMethodService {
           let utilizationPercentage = null;
 
           if (pm.type === 'credit_card') {
-            currentBalance = Math.max(0, Math.round((pm.expense_total_to_date - pm.payment_total_to_date) * 100) / 100);
+            currentBalance = await this.calculateCurrentBalance(pm.id);
             utilizationPercentage = paymentMethodBalanceService.calculateUtilizationPercentage(currentBalance, pm.credit_limit);
           }
 


### PR DESCRIPTION
## Summary\n- switch credit-card current balance calculation to use the latest billing-cycle effective balance as an anchor\n- compute current as: anchor + post-cycle expenses - post-cycle payments (floored at 0)\n- retain legacy all-time fallback when no billing-cycle anchor exists\n- align list withCounts=true current balance path with the same service calculation\n\n## Why\n- all-time aggregation can drift and disagree with billing-cycle reality\n- this keeps current balances consistent with cycle history and reduces stale/mismatched list values\n\n## Validation\n- backend targeted test: 
pm test -- paymentMethodService.balance.pbt.test.js --runInBand\n- prod spot-checks:\n  - CIBC anchored model: 3672.00 vs live 4221.75\n  - WS VISA anchored model: 3926.00 vs live 3925.92 (delta +0.08)\n