### PR TITLE
Release v1.9.5: Anchor credit-card current balance to latest billing cycle to prevent historical drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.9.5] - 2026-06-10
+
+### Anchor credit-card current balance to latest billing cycle to prevent historical drift
+
 
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Full-stack Expense Tracker Application",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker-frontend",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Expense Tracker React Frontend",
   "type": "module",
   "private": true,

--- a/frontend/src/components/system/BackupSettings.jsx
+++ b/frontend/src/components/system/BackupSettings.jsx
@@ -1215,6 +1215,13 @@ const BackupSettings = () => {
             <h3>Recent Updates</h3>
             <div className="changelog">
               <div className="changelog-entry">
+                <div className="changelog-version">v1.9.5</div>
+                <div className="changelog-date">June 10, 2026</div>
+                <ul className="changelog-items">
+                  <li>Anchor credit-card current balance to latest billing cycle to prevent historical drift</li>
+                </ul>
+              </div>
+              <div className="changelog-entry">
                 <div className="changelog-version">v1.9.4</div>
                 <div className="changelog-date">June 6, 2026</div>
                 <ul className="changelog-items">

--- a/frontend/src/components/system/SystemModal.jsx
+++ b/frontend/src/components/system/SystemModal.jsx
@@ -452,6 +452,16 @@ const SystemModal = () => {
           <div className="changelog">
             <div className="changelog-entry">
               <div className="changelog-version">
+                v1.9.5
+                {isCurrentVersion('v1.9.5') && <span className="current-version-badge">Current Version</span>}
+              </div>
+              <div className="changelog-date">June 10, 2026</div>
+              <ul className="changelog-items">
+                <li>Anchor credit-card current balance to latest billing cycle to prevent historical drift</li>
+              </ul>
+            </div>
+            <div className="changelog-entry">
+              <div className="changelog-version">
                 v1.9.4
                 {isCurrentVersion('v1.9.4') && <span className="current-version-badge">Current Version</span>}
               </div>

--- a/frontend/src/utils/changelog.js
+++ b/frontend/src/utils/changelog.js
@@ -11,6 +11,14 @@
 
 const changelogEntries = [
   {
+    version: '1.9.5',
+    date: 'June 10, 2026',
+    added: [],
+    changed: ['Anchor credit-card current balance to latest billing cycle to prevent historical drift'],
+    fixed: [],
+    removed: [],
+  },
+  {
     version: '1.9.4',
     date: 'June 6, 2026',
     added: [],


### PR DESCRIPTION
## Release v1.9.5

Anchor credit-card current balance to latest billing cycle to prevent historical drift

### Version Bump (PATCH)
- backend/package.json
- frontend/package.json
- CHANGELOG.md
- frontend/src/utils/changelog.js
- frontend/src/components/system/BackupSettings.jsx
- frontend/src/components/system/SystemModal.jsx
- Frontend rebuilt

### Post-Merge
After merging, CI will build and push the Docker image to GHCR.
Then promote locally:
```
.\scripts\build-and-push.ps1 -Environment staging
.\scripts\build-and-push.ps1 -Environment latest
```
