### PR TITLE
Recalculate anchored current balance after card payments

### DIFF
--- a/backend/services/creditCardPaymentService.currentBalance.integration.test.js
+++ b/backend/services/creditCardPaymentService.currentBalance.integration.test.js
@@ -1,0 +1,71 @@
+const { getDatabase } = require('../database/db');
+const creditCardPaymentService = require('./creditCardPaymentService');
+const { runSql } = require('../test/activityLogTestHelpers');
+const { getTodayString } = require('../utils/dateUtils');
+
+describe('CreditCardPaymentService current balance integration', () => {
+  let db;
+  let paymentMethodId;
+
+  beforeAll(async () => {
+    db = await getDatabase();
+  });
+
+  afterEach(async () => {
+    if (paymentMethodId) {
+      await runSql(db, 'DELETE FROM credit_card_payments WHERE payment_method_id = ?', [paymentMethodId]);
+      await runSql(db, 'DELETE FROM credit_card_billing_cycles WHERE payment_method_id = ?', [paymentMethodId]);
+      await runSql(db, 'DELETE FROM expenses WHERE payment_method_id = ?', [paymentMethodId]);
+      await runSql(db, 'DELETE FROM payment_methods WHERE id = ?', [paymentMethodId]);
+      paymentMethodId = null;
+    }
+  });
+
+  it('recalculates anchored current balance when recording a post-cycle payment', async () => {
+    const today = getTodayString();
+    const paymentMethodResult = await runSql(
+      db,
+      `INSERT INTO payment_methods (display_name, type, credit_limit, current_balance, payment_due_day, billing_cycle_day, is_active)
+       VALUES (?, 'credit_card', 5000, 9999, 3, 13, 1)`,
+      ['Anchor Test Visa']
+    );
+    paymentMethodId = paymentMethodResult.lastID;
+
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+    await runSql(
+      db,
+      `INSERT INTO credit_card_billing_cycles (
+        payment_method_id, cycle_start_date, cycle_end_date,
+        actual_statement_balance, calculated_statement_balance,
+        is_user_entered, effective_balance, balance_type
+      ) VALUES (?, ?, ?, ?, ?, 1, ?, 'actual')`,
+      [paymentMethodId, '2026-05-01', yesterdayStr, 1000, 1000, 1000]
+    );
+
+    await runSql(
+      db,
+      `INSERT INTO expenses (date, posted_date, place, amount, type, week, method, payment_method_id)
+       VALUES (?, ?, 'Post-cycle charge', 200, 'Other', 1, 'Anchor Test Visa', ?)`,
+      [today, today, paymentMethodId]
+    );
+
+    await creditCardPaymentService.recordPayment({
+      payment_method_id: paymentMethodId,
+      amount: 150,
+      payment_date: today,
+      notes: 'Post-cycle payment'
+    });
+
+    const updated = await new Promise((resolve, reject) => {
+      db.get('SELECT current_balance FROM payment_methods WHERE id = ?', [paymentMethodId], (err, row) => {
+        if (err) return reject(err);
+        resolve(row);
+      });
+    });
+
+    expect(updated.current_balance).toBe(1050);
+  });
+});

--- a/backend/services/creditCardPaymentService.js
+++ b/backend/services/creditCardPaymentService.js
@@ -2,6 +2,8 @@ const creditCardPaymentRepository = require('../repositories/creditCardPaymentRe
 const paymentMethodRepository = require('../repositories/paymentMethodRepository');
 const activityLogService = require('./activityLogService');
 const { runInTransaction } = require('../utils/dbHelper');
+const { calculateEffectiveBalance } = require('../utils/effectiveBalanceUtil');
+const { getTodayString } = require('../utils/dateUtils');
 const logger = require('../config/logger');
 
 /**
@@ -9,6 +11,64 @@ const logger = require('../config/logger');
  * Handles validation, business logic, and orchestration for credit card payment operations
  */
 class CreditCardPaymentService {
+  async _calculateCurrentBalanceInTransaction(tx, paymentMethodId, todayStr) {
+    const anchorCycle = await tx.get(
+      `SELECT * FROM credit_card_billing_cycles
+       WHERE payment_method_id = ?
+       ORDER BY cycle_end_date DESC
+       LIMIT 1`,
+      [paymentMethodId]
+    );
+
+    if (!anchorCycle || !anchorCycle.cycle_end_date) {
+      const expenseTotalRow = await tx.get(
+        `SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total
+         FROM expenses
+         WHERE payment_method_id = ?
+           AND COALESCE(posted_date, date) <= ?`,
+        [paymentMethodId, todayStr]
+      );
+
+      const paymentTotalRow = await tx.get(
+        `SELECT COALESCE(SUM(amount), 0) as total
+         FROM credit_card_payments
+         WHERE payment_method_id = ?
+           AND payment_date <= ?`,
+        [paymentMethodId, todayStr]
+      );
+
+      return Math.max(
+        0,
+        Math.round(((expenseTotalRow?.total || 0) - (paymentTotalRow?.total || 0)) * 100) / 100
+      );
+    }
+
+    const { effectiveBalance } = calculateEffectiveBalance(anchorCycle);
+
+    const expenseDeltaRow = await tx.get(
+      `SELECT COALESCE(SUM(COALESCE(original_cost, amount)), 0) as total
+       FROM expenses
+       WHERE payment_method_id = ?
+         AND COALESCE(posted_date, date) > ?
+         AND COALESCE(posted_date, date) <= ?`,
+      [paymentMethodId, anchorCycle.cycle_end_date, todayStr]
+    );
+
+    const paymentDeltaRow = await tx.get(
+      `SELECT COALESCE(SUM(amount), 0) as total
+       FROM credit_card_payments
+       WHERE payment_method_id = ?
+         AND payment_date > ?
+         AND payment_date <= ?`,
+      [paymentMethodId, anchorCycle.cycle_end_date, todayStr]
+    );
+
+    return Math.max(
+      0,
+      Math.round((effectiveBalance + (expenseDeltaRow?.total || 0) - (paymentDeltaRow?.total || 0)) * 100) / 100
+    );
+  }
+
   /**
    * Validate payment data
    * @param {Object} data - Payment data to validate
@@ -92,8 +152,12 @@ class CreditCardPaymentService {
         [data.payment_method_id, data.amount, data.payment_date, data.notes ? data.notes.trim() : null]
       );
 
-      const row = await tx.get('SELECT * FROM payment_methods WHERE id = ?', [data.payment_method_id]);
-      const newBalance = Math.max(0, (row.current_balance || 0) - data.amount);
+      const newBalance = await this._calculateCurrentBalanceInTransaction(
+        tx,
+        data.payment_method_id,
+        getTodayString()
+      );
+
       await tx.run(
         'UPDATE payment_methods SET current_balance = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
         [newBalance, data.payment_method_id]
@@ -256,8 +320,12 @@ class CreditCardPaymentService {
       const result = await tx.run('DELETE FROM credit_card_payments WHERE id = ?', [paymentId]);
       if (result.changes === 0) return false;
 
-      const row = await tx.get('SELECT * FROM payment_methods WHERE id = ?', [payment.payment_method_id]);
-      const newBalance = Math.max(0, (row.current_balance || 0) + payment.amount);
+      const newBalance = await this._calculateCurrentBalanceInTransaction(
+        tx,
+        payment.payment_method_id,
+        getTodayString()
+      );
+
       await tx.run(
         'UPDATE payment_methods SET current_balance = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
         [newBalance, payment.payment_method_id]


### PR DESCRIPTION
## Summary
- recalculate and persist anchored current balance when recording a credit-card payment
- recalculate and persist anchored current balance when deleting a credit-card payment
- add an integration regression test covering a post-cycle payment reducing anchored current balance

## Why
- payment create/delete was still mutating payment_methods.current_balance with the pre-anchor incremental logic
- that could leave current balance unchanged or inconsistent immediately after logging a payment

## Validation
- cd backend && npm test -- creditCardPaymentService.currentBalance.integration.test.js creditCardPaymentService.activityLog.integration.test.js --runInBand
