### PR TITLE
v1.9.6: Anchor payment-balance refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.9.6] - 2026-06-10
+
+### Handle payments after balancing is anchored
+
 ## [1.9.5] - 2026-06-10
 
 ### Anchor credit-card current balance to latest billing cycle to prevent historical drift

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Full-stack Expense Tracker Application",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expense-tracker-frontend",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Expense Tracker React Frontend",
   "type": "module",
   "private": true,

--- a/frontend/src/components/system/BackupSettings.jsx
+++ b/frontend/src/components/system/BackupSettings.jsx
@@ -1215,6 +1215,13 @@ const BackupSettings = () => {
             <h3>Recent Updates</h3>
             <div className="changelog">
               <div className="changelog-entry">
+                <div className="changelog-version">v1.9.6</div>
+                <div className="changelog-date">June 10, 2026</div>
+                <ul className="changelog-items">
+                  <li>Handle payments after balancing is anchored</li>
+                </ul>
+              </div>
+              <div className="changelog-entry">
                 <div className="changelog-version">v1.9.5</div>
                 <div className="changelog-date">June 10, 2026</div>
                 <ul className="changelog-items">

--- a/frontend/src/components/system/SystemModal.jsx
+++ b/frontend/src/components/system/SystemModal.jsx
@@ -452,6 +452,16 @@ const SystemModal = () => {
           <div className="changelog">
             <div className="changelog-entry">
               <div className="changelog-version">
+                v1.9.6
+                {isCurrentVersion('v1.9.6') && <span className="current-version-badge">Current Version</span>}
+              </div>
+              <div className="changelog-date">June 10, 2026</div>
+              <ul className="changelog-items">
+                <li>Handle payments after balancing is anchored</li>
+              </ul>
+            </div>
+            <div className="changelog-entry">
+              <div className="changelog-version">
                 v1.9.5
                 {isCurrentVersion('v1.9.5') && <span className="current-version-badge">Current Version</span>}
               </div>

--- a/frontend/src/utils/changelog.js
+++ b/frontend/src/utils/changelog.js
@@ -11,6 +11,14 @@
 
 const changelogEntries = [
   {
+    version: '1.9.6',
+    date: 'June 10, 2026',
+    added: [],
+    changed: ['Handle payments after balancing is anchored'],
+    fixed: [],
+    removed: [],
+  },
+  {
     version: '1.9.5',
     date: 'June 10, 2026',
     added: [],


### PR DESCRIPTION
## Release v1.9.6

Patch release bumping backend and frontend to `1.9.6`.

### Included changes
- Recalculate and persist the anchored current balance when recording a credit-card payment (PR #296)
- Recalculate and persist the anchored current balance when deleting a credit-card payment
- Integration regression test covering a post-cycle payment reducing the anchored current balance

### Why
- Payment create/delete previously mutated `payment_methods.current_balance` with pre-anchor incremental logic, which could leave current balance unchanged or inconsistent immediately after logging a payment.

### Validation
- `cd backend && npm test -- creditCardPaymentService.currentBalance.integration.test.js creditCardPaymentService.activityLog.integration.test.js --runInBand`
