### PR TITLE
feat(expenses): auto-suggest posted date for weekend/holiday credit-card charges

### DIFF
--- a/frontend/src/components/expenses/ExpenseForm.dataPreservation.test.jsx
+++ b/frontend/src/components/expenses/ExpenseForm.dataPreservation.test.jsx
@@ -80,10 +80,11 @@ describe('ExpenseForm - Data Preservation During Collapse', () => {
       expect(screen.getByLabelText(/^Date \*/i)).toBeInTheDocument();
     });
 
-    // Fill in core fields
+    // Fill in core fields (use a weekday so the credit-card posted date is not
+    // auto-suggested, keeping this test focused on payment-method clearing)
     const dateInput = screen.getByLabelText(/^Date \*/i);
     await user.clear(dateInput);
-    await user.type(dateInput, '2024-06-15');
+    await user.type(dateInput, '2024-06-17'); // Monday
     
     const placeInput = screen.getByLabelText(/Place/i);
     await user.type(placeInput, 'Test Place');
@@ -207,7 +208,7 @@ describe('ExpenseForm - Data Preservation During Collapse', () => {
     // Fill in core fields
     const dateInput = screen.getByLabelText(/^Date \*/i);
     await user.clear(dateInput);
-    await user.type(dateInput, '2024-06-15');
+    await user.type(dateInput, '2024-06-15'); // Saturday — triggers auto-suggested posted date
     
     const placeInput = screen.getByLabelText(/Place/i);
     await user.type(placeInput, 'Test Store');
@@ -223,11 +224,17 @@ describe('ExpenseForm - Data Preservation During Collapse', () => {
     await user.selectOptions(paymentMethodSelect, '2'); // Credit Card
 
     // Wait for posted date field and enter value
+    // Note: match the field label specifically — when a value is present the
+    // clear button (aria-label "Clear posted date") also matches /Posted Date/i.
     await waitFor(() => {
-      expect(screen.getByLabelText(/Posted Date/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^Posted Date/i)).toBeInTheDocument();
     });
 
-    const postedDateInput = screen.getByLabelText(/Posted Date/i);
+    const postedDateInput = screen.getByLabelText(/^Posted Date/i);
+    // Weekend charge: posted date is auto-suggested to the next business day.
+    // A manual override must always win, even for a weekend transaction.
+    expect(postedDateInput.value).toBe('2024-06-17'); // Monday after Sat Jun 15
+    await user.clear(postedDateInput);
     await user.type(postedDateInput, '2024-06-20');
 
     // Submit the form

--- a/frontend/src/components/expenses/ExpenseForm.jsx
+++ b/frontend/src/components/expenses/ExpenseForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useModalContext } from '../../contexts/ModalContext';
 import { API_ENDPOINTS } from '../../config';
 import { getTodayLocalDate } from '../../utils/formatters';
+import { isBusinessDay, nextBusinessDay } from '../../utils/businessDays';
 import { getCategories } from '../../services/categoriesApi';
 import { getPeople } from '../../services/peopleApi';
 import { createExpense, updateExpense, getExpenseWithPeople } from '../../services/expenseApi';
@@ -79,6 +80,12 @@ const ExpenseForm = ({ onExpenseAdded, people: propPeople, expense = null }) => 
   // Initialize from expense prop when editing
   const [postedDate, setPostedDate] = useState(expense?.posted_date || '');
 
+  // Whether the Posted Date is auto-managed (system suggests next business day
+  // for weekend/holiday credit-card charges). Becomes false once the user types
+  // or clears the field, so manual values are always respected. Disabled in edit
+  // mode so opening an existing expense never silently changes its posted date.
+  const [postedDateAutoManaged, setPostedDateAutoManaged] = useState(!isEditing);
+
   // Use extracted payment methods hook (Requirements 1.7, 7.1)
   const {
     paymentMethods,
@@ -102,6 +109,25 @@ const ExpenseForm = ({ onExpenseAdded, people: propPeople, expense = null }) => 
     filterPlaces,
     fetchPlaces
   } = usePlaceAutocomplete();
+
+  // Auto-manage the Posted Date for credit-card charges made on a weekend or
+  // Canadian bank holiday: suggest the next business day, and clear the
+  // suggestion when the transaction date moves to a business day or the payment
+  // method is no longer a credit card. Skips entirely once the user has taken
+  // manual control (postedDateAutoManaged === false).
+  useEffect(() => {
+    if (!postedDateAutoManaged) return;
+    const selectedMethod = paymentMethods.find(pm => pm.id === formData.payment_method_id)
+      || editingInactivePaymentMethod;
+    const creditCard = selectedMethod?.type === 'credit_card';
+    if (creditCard && formData.date && !isBusinessDay(formData.date)) {
+      const suggested = nextBusinessDay(formData.date);
+      setPostedDate(prev => (prev === suggested ? prev : suggested));
+    } else {
+      setPostedDate(prev => (prev === '' ? prev : ''));
+    }
+    setPostedDateError('');
+  }, [formData.date, formData.payment_method_id, postedDateAutoManaged, paymentMethods, editingInactivePaymentMethod]);
 
   // Section expansion state management (Requirements 1.3, 11.2, 11.5)
   // Calculate initial expansion states based on mode and existing data
@@ -370,6 +396,8 @@ const ExpenseForm = ({ onExpenseAdded, people: propPeople, expense = null }) => 
       if (!newPaymentMethod || newPaymentMethod.type !== 'credit_card') {
         setPostedDate('');
         setPostedDateError('');
+        // Resume auto-suggestion the next time a credit card is selected
+        setPostedDateAutoManaged(true);
       }
       return;
     }
@@ -526,7 +554,9 @@ const ExpenseForm = ({ onExpenseAdded, people: propPeople, expense = null }) => 
   const handlePostedDateChange = (e) => {
     const value = e.target.value;
     setPostedDate(value);
-    
+    // User is taking manual control: stop auto-suggesting the posted date
+    setPostedDateAutoManaged(false);
+
     // Clear validation error when value changes
     setPostedDateError('');
     
@@ -1086,6 +1116,8 @@ const ExpenseForm = ({ onExpenseAdded, people: propPeople, expense = null }) => 
                   onClick={() => {
                     setPostedDate('');
                     setPostedDateError('');
+                    // Explicit clear is a manual choice — keep it empty
+                    setPostedDateAutoManaged(false);
                   }}
                   disabled={isSubmitting}
                   title="Clear posted date"
@@ -1096,7 +1128,9 @@ const ExpenseForm = ({ onExpenseAdded, people: propPeople, expense = null }) => 
               )}
             </div>
             <small className="form-hint">
-              Leave empty to use transaction date
+              {postedDateAutoManaged && postedDate
+                ? 'Auto-set to the next business day (weekend/holiday charge). Edit or clear to override.'
+                : 'Leave empty to use transaction date'}
             </small>
             {postedDateError && (
               <div className="posted-date-error">

--- a/frontend/src/utils/businessDays.js
+++ b/frontend/src/utils/businessDays.js
@@ -1,0 +1,160 @@
+/**
+ * Business-day utilities for Canadian (Ontario) bank holidays.
+ *
+ * Credit-card transactions made on a non-business day (weekend or statutory
+ * bank holiday) typically do not post until the next business day. The expense
+ * form uses these helpers to suggest a default Posted Date, which the user can
+ * always override or clear.
+ *
+ * Dates are handled as YYYY-MM-DD strings using UTC math to avoid local
+ * timezone day-shifts. The holiday set reflects statutory holidays observed by
+ * banks in Ontario (the app's America/Toronto business timezone). Fixed-date
+ * holidays that fall on a weekend are observed on the following business day.
+ */
+
+/** Parse a YYYY-MM-DD string into a UTC-midnight Date. */
+function parseUTC(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+/** Format a UTC Date back to a YYYY-MM-DD string. */
+function formatUTC(date) {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Add (or subtract) days to a YYYY-MM-DD string, returning a YYYY-MM-DD string. */
+function addDays(dateStr, days) {
+  const date = parseUTC(dateStr);
+  date.setUTCDate(date.getUTCDate() + days);
+  return formatUTC(date);
+}
+
+/** True if the date falls on a Saturday or Sunday. */
+export function isWeekend(dateStr) {
+  const dow = parseUTC(dateStr).getUTCDay();
+  return dow === 0 || dow === 6;
+}
+
+/**
+ * Nth occurrence of a weekday within a month.
+ * @param {number} year
+ * @param {number} month - 1-12
+ * @param {number} weekday - 0=Sun .. 6=Sat
+ * @param {number} n - 1-based occurrence (e.g. 3 = third Monday)
+ * @returns {string} YYYY-MM-DD
+ */
+function nthWeekdayOfMonth(year, month, weekday, n) {
+  const firstDow = new Date(Date.UTC(year, month - 1, 1)).getUTCDay();
+  const day = 1 + ((weekday - firstDow + 7) % 7) + (n - 1) * 7;
+  return formatUTC(new Date(Date.UTC(year, month - 1, day)));
+}
+
+/** Victoria Day: the Monday preceding May 25. */
+function victoriaDay(year) {
+  const refDow = new Date(Date.UTC(year, 4, 25)).getUTCDay(); // May 25
+  let back = (refDow - 1 + 7) % 7; // days back to the most recent Monday
+  if (back === 0) back = 7; // strictly preceding when May 25 is itself a Monday
+  return formatUTC(new Date(Date.UTC(year, 4, 25 - back)));
+}
+
+/** Easter Sunday via the Anonymous Gregorian (Meeus/Jones/Butcher) algorithm. */
+function easterSunday(year) {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const mm = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * mm + 114) / 31); // 3 = March, 4 = April
+  const day = ((h + l - 7 * mm + 114) % 31) + 1;
+  return formatUTC(new Date(Date.UTC(year, month - 1, day)));
+}
+
+/** Good Friday: the Friday before Easter Sunday. */
+function goodFriday(year) {
+  return addDays(easterSunday(year), -2);
+}
+
+/**
+ * Add a fixed-date holiday to the set, applying in-lieu observance: if it falls
+ * on a weekend, it is observed on the next non-holiday weekday instead.
+ */
+function addObserved(set, dateStr) {
+  if (!isWeekend(dateStr)) {
+    set.add(dateStr);
+    return;
+  }
+  let d = dateStr;
+  do {
+    d = addDays(d, 1);
+  } while (isWeekend(d) || set.has(d));
+  set.add(d);
+}
+
+const holidayCache = new Map();
+
+/**
+ * Set of YYYY-MM-DD statutory bank-holiday dates for a given year (Ontario).
+ * @param {number} year
+ * @returns {Set<string>}
+ */
+export function getHolidaysForYear(year) {
+  if (holidayCache.has(year)) {
+    return holidayCache.get(year);
+  }
+
+  const set = new Set();
+
+  // Fixed-date holidays — observed on the next business day when on a weekend.
+  addObserved(set, `${year}-01-01`); // New Year's Day
+  addObserved(set, `${year}-07-01`); // Canada Day
+  addObserved(set, `${year}-12-25`); // Christmas Day
+  addObserved(set, `${year}-12-26`); // Boxing Day
+
+  // Floating Monday holidays — always land on a weekday.
+  set.add(nthWeekdayOfMonth(year, 2, 1, 3)); // Family Day — 3rd Monday of February
+  set.add(victoriaDay(year)); // Victoria Day — Monday preceding May 25
+  set.add(nthWeekdayOfMonth(year, 8, 1, 1)); // Civic Holiday — 1st Monday of August
+  set.add(nthWeekdayOfMonth(year, 9, 1, 1)); // Labour Day — 1st Monday of September
+  set.add(nthWeekdayOfMonth(year, 10, 1, 2)); // Thanksgiving — 2nd Monday of October
+
+  // Good Friday — Friday before Easter Sunday.
+  set.add(goodFriday(year));
+
+  holidayCache.set(year, set);
+  return set;
+}
+
+/** True if the date is a statutory bank holiday in Ontario. */
+export function isHoliday(dateStr) {
+  const year = parseUTC(dateStr).getUTCFullYear();
+  return getHolidaysForYear(year).has(dateStr);
+}
+
+/** True if the date is a business day (not a weekend and not a bank holiday). */
+export function isBusinessDay(dateStr) {
+  return !isWeekend(dateStr) && !isHoliday(dateStr);
+}
+
+/**
+ * The next business day strictly after the given date.
+ * @param {string} dateStr - YYYY-MM-DD
+ * @returns {string} YYYY-MM-DD of the next business day
+ */
+export function nextBusinessDay(dateStr) {
+  let d = addDays(dateStr, 1);
+  while (!isBusinessDay(d)) {
+    d = addDays(d, 1);
+  }
+  return d;
+}

--- a/frontend/src/utils/businessDays.test.js
+++ b/frontend/src/utils/businessDays.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWeekend,
+  isHoliday,
+  isBusinessDay,
+  nextBusinessDay,
+  getHolidaysForYear,
+} from './businessDays';
+
+describe('businessDays', () => {
+  describe('isWeekend', () => {
+    it('returns true for Saturday and Sunday', () => {
+      expect(isWeekend('2026-06-13')).toBe(true); // Saturday
+      expect(isWeekend('2026-06-14')).toBe(true); // Sunday
+    });
+
+    it('returns false for weekdays', () => {
+      expect(isWeekend('2026-06-15')).toBe(false); // Monday
+      expect(isWeekend('2026-06-12')).toBe(false); // Friday
+    });
+  });
+
+  describe('getHolidaysForYear (2026, Ontario)', () => {
+    const holidays = getHolidaysForYear(2026);
+
+    it('includes the expected statutory bank holidays', () => {
+      expect(holidays.has('2026-01-01')).toBe(true); // New Year's Day (Thu)
+      expect(holidays.has('2026-02-16')).toBe(true); // Family Day — 3rd Mon Feb
+      expect(holidays.has('2026-04-03')).toBe(true); // Good Friday
+      expect(holidays.has('2026-05-18')).toBe(true); // Victoria Day
+      expect(holidays.has('2026-07-01')).toBe(true); // Canada Day (Wed)
+      expect(holidays.has('2026-08-03')).toBe(true); // Civic Holiday — 1st Mon Aug
+      expect(holidays.has('2026-09-07')).toBe(true); // Labour Day — 1st Mon Sep
+      expect(holidays.has('2026-10-12')).toBe(true); // Thanksgiving — 2nd Mon Oct
+      expect(holidays.has('2026-12-25')).toBe(true); // Christmas (Fri)
+    });
+
+    it('observes Boxing Day on the next business day when it falls on a weekend', () => {
+      // Dec 26 2026 is a Saturday -> observed Monday Dec 28
+      expect(holidays.has('2026-12-28')).toBe(true);
+    });
+  });
+
+  describe('observed in-lieu days for fixed holidays on weekends', () => {
+    it('observes Christmas + Boxing Day cascade when both fall on a weekend', () => {
+      // 2027: Dec 25 = Saturday, Dec 26 = Sunday -> observed Mon Dec 27 and Tue Dec 28
+      const holidays = getHolidaysForYear(2027);
+      expect(holidays.has('2027-12-27')).toBe(true);
+      expect(holidays.has('2027-12-28')).toBe(true);
+    });
+
+    it('observes New Year\'s Day on Monday when Jan 1 is a Saturday', () => {
+      // Jan 1 2028 is a Saturday -> observed Monday Jan 3
+      const holidays = getHolidaysForYear(2028);
+      expect(holidays.has('2028-01-03')).toBe(true);
+    });
+  });
+
+  describe('isHoliday', () => {
+    it('recognizes a known holiday', () => {
+      expect(isHoliday('2026-12-25')).toBe(true);
+    });
+
+    it('returns false for an ordinary weekday', () => {
+      expect(isHoliday('2026-06-15')).toBe(false);
+    });
+  });
+
+  describe('isBusinessDay', () => {
+    it('is false on weekends and holidays', () => {
+      expect(isBusinessDay('2026-06-13')).toBe(false); // Saturday
+      expect(isBusinessDay('2026-12-25')).toBe(false); // Christmas
+    });
+
+    it('is true on ordinary weekdays', () => {
+      expect(isBusinessDay('2026-06-15')).toBe(true); // Monday
+    });
+  });
+
+  describe('nextBusinessDay', () => {
+    it('rolls a Saturday charge to the following Monday', () => {
+      expect(nextBusinessDay('2026-06-13')).toBe('2026-06-15'); // Sat -> Mon
+    });
+
+    it('rolls a Sunday charge to the following Monday', () => {
+      expect(nextBusinessDay('2026-06-14')).toBe('2026-06-15'); // Sun -> Mon
+    });
+
+    it('skips a holiday that follows the weekend', () => {
+      // Good Friday Apr 3 2026 -> Sat Apr 4, Sun Apr 5, Mon Apr 6
+      expect(nextBusinessDay('2026-04-03')).toBe('2026-04-06');
+    });
+
+    it('crosses a year boundary correctly', () => {
+      // Thu Dec 31 2026 -> Fri Jan 1 2027 (New Year's, holiday), Sat, Sun -> Mon Jan 4
+      expect(nextBusinessDay('2026-12-31')).toBe('2027-01-04');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Auto-suggests a **Posted Date** for credit-card charges made on a non-business day (weekend or Ontario bank holiday), so transactions that won't settle until the next business day land in the correct billing cycle. Frontend-only; backend behavior is unchanged.

## Behavior
- Credit card + transaction date on a weekend/holiday -> Posted Date auto-fills with the next business day, with an explanatory hint.
- Changing the transaction date recomputes the suggestion, or clears it when the date moves to a business day.
- Manual edits or clears always win; switching away from a credit card clears and hides the field.
- Edit mode never silently changes a saved expense's posted date (auto-management starts off when editing). Correcting a saved expense's payment method to a credit card re-enables the suggestion, matching create-mode behavior.

## Edge cases
- A weekend charge that genuinely posted same-day: user types the real posted date and it is respected.
- Manual posted dates remain fully supported in all flows.

## Implementation
- New `frontend/src/utils/businessDays.js`: Ontario statutory bank-holiday calendar (fixed + floating holidays, Good Friday via Easter calc, in-lieu weekend observance) with `isBusinessDay` / `nextBusinessDay` helpers operating on `YYYY-MM-DD` strings (UTC math, no timezone drift).
- `ExpenseForm.jsx`: auto-manage effect keyed on date/payment method, manual-override tracking, and hint text.
- Backend untouched — still keys cycle/balance math off `COALESCE(posted_date, date)`.

## Tests
- New `businessDays.test.js` (14 tests: weekends, holidays, in-lieu cascades, year-boundary rollover).
- Updated 2 `ExpenseForm.dataPreservation` tests for the new auto-fill (one isolates payment-method clearing on a weekday; one asserts a manual override beats the weekend suggestion).
- All ExpenseForm suites pass (104 passed, 6 skipped).

> Note: the holiday list is Ontario-specific and hardcoded in `businessDays.js` — single file to edit for other provinces or one-off bank holidays.