### PR TITLE
ci(release): create verified commits via GitHub API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,10 +173,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Enable auto-merge with a PAT (not GITHUB_TOKEN). When auto-merge completes
+      # under GITHUB_TOKEN, the resulting push to main does NOT trigger downstream
+      # workflows (GitHub's recursion guard), so the GHCR build/push never runs.
+      # A PAT (secret RELEASE_PAT, repo scope) attributes the merge to a real user,
+      # so the merge push triggers the CI build-and-push-ghcr job.
       - name: Enable auto-merge
         if: inputs.auto_merge
         run: |
           gh pr merge "${{ steps.version.outputs.branch }}" --auto --merge --delete-branch
           echo "✅ Auto-merge enabled — PR will merge when CI passes" >> $GITHUB_STEP_SUMMARY
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Create release branch
         run: |
           git checkout -b "${{ steps.version.outputs.branch }}"
+          # Push the branch pointing at main's (already-verified) tip so the
+          # GitHub API can add a verified commit to it in the commit step.
+          git push -u origin "${{ steps.version.outputs.branch }}"
 
       - name: Bump version in package.json files
         run: |
@@ -119,16 +122,17 @@ jobs:
           npm ci
           npm run build
 
-      - name: Commit changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "v${{ steps.version.outputs.new }}: ${{ inputs.description }}"
-
-      - name: Push release branch
-        run: |
-          git push -u origin "${{ steps.version.outputs.branch }}"
+      # Commit & push via the GitHub API so the commit is signed by GitHub's
+      # key and shows as "Verified" (required by branch protection). A plain
+      # `git commit` / `git push` from CI produces unsigned, unverified commits.
+      - name: Commit changes (verified)
+        uses: planetscale/ghcommit-action@v0.2.22
+        with:
+          commit_message: "v${{ steps.version.outputs.new }}: ${{ inputs.description }}"
+          repo: ${{ github.repository }}
+          branch: ${{ steps.version.outputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
         id: create_pr


### PR DESCRIPTION
## Problem

The "Create Release PR" workflow committed version bumps with a plain `git commit` as `github-actions[bot]`. Those commits are unsigned, so branch protection's "Commits must have verified signatures" rule blocks the resulting release PR from merging (e.g. #303).

## Fix

- Push the release branch pointing at main's already-verified tip, then create the version-bump commit through the GitHub API via `planetscale/ghcommit-action`. Commits made through the API with `GITHUB_TOKEN` are signed by GitHub and show as Verified — no GPG/SSH key secrets to manage.
- Replaces the `Commit changes` + `Push release branch` steps.

## Notes

- `permissions: contents: write` is already set, which ghcommit-action needs.
- Future release PRs will be mergeable without manual re-signing.
