### PR TITLE
ci(release): verified commit via gh graphql (drop blocked third-party action)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,17 +122,64 @@ jobs:
           npm ci
           npm run build
 
-      # Commit & push via the GitHub API so the commit is signed by GitHub's
-      # key and shows as "Verified" (required by branch protection). A plain
-      # `git commit` / `git push` from CI produces unsigned, unverified commits.
+      # Commit via the GitHub API (GraphQL createCommitOnBranch) so the commit
+      # is signed by GitHub's key and shows as "Verified" (required by branch
+      # protection). A plain `git commit` / `git push` from CI produces
+      # unsigned, unverified commits. Using the built-in `gh` CLI avoids any
+      # third-party action (kept off the repo Actions allowlist).
       - name: Commit changes (verified)
-        uses: planetscale/ghcommit-action@v0.2.22
-        with:
-          commit_message: "v${{ steps.version.outputs.new }}: ${{ inputs.description }}"
-          repo: ${{ github.repository }}
-          branch: ${{ steps.version.outputs.branch }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          MESSAGE: "v${{ steps.version.outputs.new }}: ${{ inputs.description }}"
+        run: |
+          set -euo pipefail
+
+          # The release branch was pushed at main's tip and has not advanced,
+          # so HEAD is the expected head OID for the branch on the remote.
+          HEAD_OID=$(git rev-parse HEAD)
+
+          # Build fileChanges.additions (modified/added tracked files, base64).
+          ADDITIONS='[]'
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            B64=$(base64 -w0 "$f")
+            ADDITIONS=$(printf '%s' "$ADDITIONS" | jq --arg path "$f" --arg contents "$B64" '. + [{path: $path, contents: $contents}]')
+          done < <(git diff --name-only --no-renames --diff-filter=d HEAD)
+
+          # Build fileChanges.deletions (removed tracked files).
+          DELETIONS='[]'
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            DELETIONS=$(printf '%s' "$DELETIONS" | jq --arg path "$f" '. + [{path: $path}]')
+          done < <(git diff --name-only --no-renames --diff-filter=D HEAD)
+
+          if [ "$ADDITIONS" = '[]' ] && [ "$DELETIONS" = '[]' ]; then
+            echo "No file changes to commit" >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg oid "$HEAD_OID" \
+            --arg headline "$MESSAGE" \
+            --argjson additions "$ADDITIONS" \
+            --argjson deletions "$DELETIONS" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: $headline },
+                  expectedHeadOid: $oid,
+                  fileChanges: { additions: $additions, deletions: $deletions }
+                }
+              }
+            }' > /tmp/commit-payload.json
+
+          gh api graphql --input /tmp/commit-payload.json
 
       - name: Create Pull Request
         id: create_pr


### PR DESCRIPTION
## Problem
The `Create Release PR` workflow failed with a `startup_failure`:

> The action `planetscale/ghcommit-action@v0.2.22` is not allowed in `krazykrazz/Expense-Tracker` because all actions must be from a repository owned by krazykrazz, created by GitHub, or match one of the allowlist patterns.

The repo restricts Actions to a curated allowlist (`allowed_actions: selected`), and the third-party `planetscale/ghcommit-action` (used to push the *verified* version-bump commit) isn't on it.

## Fix
Replace the action with a native **`gh api graphql createCommitOnBranch`** step. This:
- Produces **GitHub-signed (Verified)** commits, satisfying branch protection (the reason the action was used).
- Uses only the built-in `gh` CLI — no third-party action, so **no Actions allowlist change** is needed.
- Derives file additions (base64) and deletions from the working tree via `git diff --no-renames` (rename-safe).
- Passes untrusted `inputs.description` via an `env` var (not inline template interpolation) to avoid script injection.

## Validation
- Workflow YAML parses cleanly; the commit step is now a `run` step (no `uses`).
- After merge, re-running the release workflow will exercise the new step end-to-end.
