### PR TITLE
ci(release): use npm install for frontend build (tolerate lockfile drift)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,11 @@ jobs:
       - name: Build frontend
         run: |
           cd frontend
-          npm ci
+          # Use `npm install` (matching ci.yml) rather than `npm ci`: the
+          # committed lockfile can drift on cross-platform optional deps
+          # (e.g. @emnapi/*), which `npm ci` rejects. `--no-package-lock`
+          # keeps the build from mutating the lockfile into the release commit.
+          npm install --no-package-lock
           npm run build
 
       # Commit via the GitHub API (GraphQL createCommitOnBranch) so the commit


### PR DESCRIPTION
The re-run of the release workflow failed at the `Build frontend` step:

    npm error EUSAGE ... npm ci can only install when package.json and package-lock.json are in sync
    npm error Missing: @emnapi/core@1.11.1 from lock file
    npm error Missing: @emnapi/runtime@1.11.1 from lock file

release.yml was the only workflow using strict `npm ci`. The committed frontend lockfile drifts on cross-platform optional deps (@emnapi/* package entries pruned when npm runs on Windows), which `npm ci` rejects. The rest of CI (ci.yml) uses `npm install` and tolerates this.

**Fix:** align the release build step with ci.yml by using `npm install`. `--no-package-lock` prevents the build from mutating the lockfile into the verified release commit.

_Follow-up (optional): regenerate the frontend lockfile on Linux to make it npm ci-clean; flagged separately._