### PR TITLE
ci: restore release npm ci + add lockfile-integrity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,32 @@ jobs:
             echo "empty_pr=false" >> $GITHUB_OUTPUT
           fi
 
+  lockfile-integrity:
+    name: Lockfile Integrity
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # Guards against committed lockfiles drifting from package.json — e.g.
+      # cross-platform optional deps (@emnapi/*) get pruned when npm runs on
+      # Windows, producing a lockfile that `npm ci` rejects. Without this,
+      # such drift only surfaces in the release workflow's `npm ci` build.
+      - name: Verify lockfiles are npm ci-installable
+        run: |
+          set -e
+          for dir in . backend frontend; do
+            echo "::group::npm ci ($dir)"
+            (cd "$dir" && npm ci --ignore-scripts --no-audit --no-fund)
+            echo "::endgroup::"
+          done
+
   backend-unit-tests:
     name: Backend Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,11 +119,7 @@ jobs:
       - name: Build frontend
         run: |
           cd frontend
-          # Use `npm install` (matching ci.yml) rather than `npm ci`: the
-          # committed lockfile can drift on cross-platform optional deps
-          # (e.g. @emnapi/*), which `npm ci` rejects. `--no-package-lock`
-          # keeps the build from mutating the lockfile into the release commit.
-          npm install --no-package-lock
+          npm ci
           npm run build
 
       # Commit via the GitHub API (GraphQL createCommitOnBranch) so the commit


### PR DESCRIPTION
Slimmed from the original: the lockfile drift this targeted is now resolved on `main` (the recent Dependabot bumps regenerated the lockfiles clean on Linux), so this keeps only the two durable workflow improvements:

- **Restore `npm ci`** in `release.yml`'s frontend build (reverts the temporary `npm install --no-package-lock` workaround) for reproducible release builds.
- **Add a `Lockfile Integrity` CI job** running `npm ci --ignore-scripts` for root/backend/frontend, so future lockfile drift (e.g. cross-platform `@emnapi/*` pruning from a Windows-committed lockfile) fails a PR instead of only surfacing in the release workflow.

Verified: `npm ci` passes for all three projects against current `main` in a clean `node:20-alpine` container.