### PR TITLE
ci: bump Node from 20 to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       # Guards against committed lockfiles drifting from package.json — e.g.
       # cross-platform optional deps (@emnapi/*) get pruned when npm runs on
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: backend/package-lock.json
 
@@ -192,7 +192,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: backend/package-lock.json
 
@@ -288,7 +288,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
@@ -350,7 +350,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: |
             backend/package-lock.json
@@ -420,7 +420,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Report test health
         run: node scripts/report-test-health.js >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Calculate new version
         id: version


### PR DESCRIPTION
Bumps all `actions/setup-node` steps from Node 20 to Node 22 across `ci.yml` and `release.yml`.

## Why

jsdom 30 (PR #330) requires Node `^22.22.2 || ^24.15.0 || >=26.0.0` and drops Node 20 support. CI currently runs on Node 20, so the frontend test job would hit `EBADENGINE` and risk runtime failures. Bumping to Node 22 unblocks #330.

## Changes

- 6 setup-node steps in `.github/workflows/ci.yml` -> Node 22
- 1 setup-node step in `.github/workflows/release.yml` -> Node 22

## Notes

- Once merged, rebase #330 (jsdom 29->30) onto main; its full frontend suite passed locally (2474 passed, 7 skipped).
- The `lockfile-integrity` job runs `npm ci` on the new runtime; CI will confirm the committed lockfiles install cleanly on Node 22.