### PR TITLE
fix(docker): remove global npm from runtime image to clear tar CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ ARG GIT_COMMIT=unknown
 
 # Upgrade all system packages to fix known vulnerabilities, then install extras
 RUN apk upgrade --no-cache && \
-    apk add --no-cache tzdata wget
+    apk add --no-cache tzdata wget && \
+    # Remove global npm/npx: unused at runtime and its bundled tar carries CVEs
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Problem

The `Build and Push to GHCR` job failed on main ([run](https://github.com/krazykrazz/Expense-Tracker/actions/runs/30701481401/job/91373676278)): Trivy flagged **CVE-2026-59873** (CRITICAL) \u2014 `tar` 6.2.1, node-tar DoS via crafted gzip bomb, fixed in 7.5.19.

## Root cause

The app's own `tar` is already 7.5.22 (patched). The vulnerable 6.2.1 is the copy **bundled inside global npm** in the `node:20-alpine` base image. CVE-2026-59873 needs tar >= 7.5.19, which only the latest npm bundles \u2014 so bumping the base image alone wouldn't reliably fix it.

## Fix

The runtime image runs `node server.js` and never invokes npm/npx (verified \u2014 no runtime npm calls in backend). Removing global npm/npx from the final stage eliminates the vulnerable bundled tar and reduces attack surface.

## Validation

Built the image locally and confirmed:
- `npm`/`npx` absent
- Only `tar` remaining is `/app/node_modules/tar` @ **7.5.22** (>= 7.5.19)

Trivy should now report 0 CRITICAL.