### PR TITLE
chore(docker): align image to Node 22 and pin deps via lockfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-package-lock.json
+# package-lock.json is kept in context so `npm install` pins versions (reproducible builds)
 
 # Development
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Frontend Builder
-FROM node:20-alpine AS frontend-builder
+FROM node:22-alpine AS frontend-builder
 
 RUN apk upgrade --no-cache
 
@@ -21,7 +21,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Backend Dependencies
-FROM node:20-alpine AS backend-deps
+FROM node:22-alpine AS backend-deps
 
 # Install build dependencies for native modules (sqlite3)
 RUN apk upgrade --no-cache && \
@@ -36,7 +36,7 @@ COPY backend/package*.json ./
 RUN npm install --omit=dev
 
 # Stage 3: Final Runtime
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Build arguments for version info
 ARG IMAGE_TAG=unknown
@@ -62,7 +62,7 @@ COPY --from=frontend-builder /build/frontend/dist ./frontend/dist
 COPY --from=backend-deps /build/backend/node_modules ./node_modules
 
 # Create /config directory structure and set ownership
-# Note: node:20-alpine already has a 'node' user with UID 1000
+# Note: node:22-alpine already has a 'node' user with UID 1000
 RUN mkdir -p /config/database /config/backups /config/config /config/invoices /config/invoices/temp && \
     chown -R node:node /config /app
 


### PR DESCRIPTION
Follow-ups to the Trivy/npm fix (#333).

## Changes

1. **Node 20 -> 22** for all three Dockerfile stages, matching the CI runtime (setup-node bumped to 22 in #332).
2. **Pin dependencies:** stop excluding `package-lock.json` in `.dockerignore` so the image build's `npm install` honors the lockfile (reproducible builds + keeps the patched `tar` pinned).

### Why keep `npm install` instead of `npm ci`?

Alpine uses **musl**, and the `lockfile-integrity` CI job only verifies `npm ci` on glibc/ubuntu. `npm ci` on Alpine can fail on musl-specific optional deps (`@esbuild/*-musl`, `@emnapi/*`). `npm install` with the lockfile present pins versions while staying musl-safe.

## Validation (local Docker build)

- Image builds on `node:22-alpine`
- `node -v` -> **v22.23.2**; `npm`/`npx` absent
- Only `tar` present is `/app/node_modules/tar` @ **7.5.22** (patched)
- Container boots: DB connected, `/api/health` returns `ok` (native sqlite3 OK on Node 22)